### PR TITLE
Change POST and DELETE return codes

### DIFF
--- a/main.py
+++ b/main.py
@@ -427,7 +427,7 @@ class Main(KytosNApp):
             self._install_flows(command, flows_dict,
                                 self._get_all_switches_enabled())
 
-        return jsonify({"response": "FlowMod Messages Sent"})
+        return jsonify({"response": "FlowMod Messages Sent"}), 202
 
     def _install_flows(self, command, flows_dict, switches=[]):
         """Execute all procedures to install flows in the switches.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -108,7 +108,7 @@ class TestMain(TestCase):
             response_1 = api.post(url, json={'flows': [{"priority": 25}]})
             response_2 = api.post(url)
 
-            self.assertEqual(response_1.status_code, 200)
+            self.assertEqual(response_1.status_code, 202)
             self.assertEqual(response_2.status_code, 400)
 
         self.assertEqual(mock_install_flows.call_count, 2)
@@ -125,9 +125,9 @@ class TestMain(TestCase):
             response_1 = api.post(url_1, json=data)
             response_2 = api.post(url_2, json=data)
 
-            self.assertEqual(response_1.status_code, 200)
+            self.assertEqual(response_1.status_code, 202)
             if method == 'delete':
-                self.assertEqual(response_2.status_code, 200)
+                self.assertEqual(response_2.status_code, 202)
 
         self.assertEqual(mock_install_flows.call_count, 3)
 


### PR DESCRIPTION
Fixes #20 and #21.

POST and DELETE methods were returning 200 but should return 202 when the NApp sucessfully send the flows to the switches.
They don't return 201 because as the communication with the switch is asynchronous there is no answer from the switch to be returned to the client.