### PR TITLE
Fix/issue 13

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,18 @@ Removed
 Security
 ========
 
+[4.1] - 2021-10.22
+******************
+
+Changed
+=======
+- Removed 'delete' command persistency
+- Faster filtering when removing stored flows
+
+Fixed
+=====
+- Fixed ``match13_no_strict`` issue 13
+
 
 [4.0] - 2021-05-27
 ******************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "4.0",
+  "version": "4.1",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -262,7 +262,7 @@ class Main(KytosNApp):
         installed_flow = {}
         installed_flow['command'] = command
         installed_flow['flow'] = flow
-        should_persist_flow = True if command == "add" else False
+        should_persist_flow = command == "add"
         deleted_flows_idxs = set()
 
         serializer = FlowFactory.get_class(switch)

--- a/main.py
+++ b/main.py
@@ -299,11 +299,12 @@ class Main(KytosNApp):
                     deleted_flows_idxs.add(i)
                     break
 
-            stored_flows = [
-                flow
-                for i, flow in enumerate(stored_flows)
-                if i not in deleted_flows_idxs
-            ]
+            if deleted_flows_idxs:
+                stored_flows = [
+                    flow
+                    for i, flow in enumerate(stored_flows)
+                    if i not in deleted_flows_idxs
+                ]
             if should_persist_flow:
                 stored_flows.append(installed_flow)
             stored_flows_box[switch.id]['flow_list'] = stored_flows

--- a/match.py
+++ b/match.py
@@ -108,33 +108,31 @@ def match10_no_strict(flow_dict, args):
 
 
 def match13_no_strict(flow_to_install, stored_flow_dict):
-    """Match a packet againts the stored flow (OF 1.3).
+    """Match a flow that is either exact or more specific (non-strict) (OF1.3).
 
     Return the flow if any fields match, otherwise, return False.
     """
-    if flow_to_install.get('cookie_mask') and 'cookie' in stored_flow_dict:
-        cookie = flow_to_install['cookie'] & flow_to_install['cookie_mask']
-        stored_cookie = (stored_flow_dict['cookie'] &
-                         flow_to_install['cookie_mask'])
-        if cookie == stored_cookie:
-            return stored_flow_dict
-        return False
-    if 'match' not in flow_to_install:
+
+    if 'match' not in flow_to_install or 'match' not in stored_flow_dict:
+        return stored_flow_dict
+    if not flow_to_install['match']:
+        return stored_flow_dict
+    if len(flow_to_install['match']) > len(stored_flow_dict['match']):
         return False
 
     for key, value in flow_to_install.get('match').items():
-        if 'match' not in stored_flow_dict:
+        if key not in stored_flow_dict['match']:
             return False
-        if key not in ('ipv4_src', 'ipv4_dst', 'ipv6_src', 'ipv6_dst'):
-            if value == stored_flow_dict['match'].get(key):
-                return stored_flow_dict
-        else:
-            field = stored_flow_dict['match'].get(key)
-            if not field:
+        if value != stored_flow_dict['match'].get(key):
+            return False
+
+    key_masks = {"cookie": "cookie_mask"}
+    for key, key_mask in key_masks.items():
+        if flow_to_install.get(key_mask) and key in stored_flow_dict:
+            value = flow_to_install[key] & flow_to_install[key_mask]
+            stored_value = (stored_flow_dict[key] &
+                            flow_to_install[key_mask])
+            if value != stored_value:
                 return False
-            masked_ip_addr = ipaddress.ip_network(value, False)
-            field_mask = field + "/" + str(masked_ip_addr.netmask)
-            masked_stored_ip = ipaddress.ip_network(field_mask, False)
-            if masked_ip_addr == masked_stored_ip:
-                return stored_flow_dict
-    return False
+
+    return stored_flow_dict

--- a/match.py
+++ b/match.py
@@ -112,7 +112,6 @@ def match13_no_strict(flow_to_install, stored_flow_dict):
 
     Return the flow if any fields match, otherwise, return False.
     """
-
     if 'match' not in flow_to_install or 'match' not in stored_flow_dict:
         return stored_flow_dict
     if not flow_to_install['match']:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'flow_manager'
-NAPP_VERSION = '4.0'
+NAPP_VERSION = '4.1'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'


### PR DESCRIPTION
Fixes #13 

In addition to fixing the non strict logic matching of this func `match13_no_strict`, I've also changed how the `delete` command flows were store because of these reasons (since as a result of the match I was already dealing with the stored flows):

1) `_store_changed_flows` is already storing the managed flows on `stored_flows`, and any removed flows were already being excluded from that list, so, at that point `flow_manager` knows that the previous added flows are supposed to be gone, and the consistency checks, assuming that our matching logic is coherent keeping the flows on `stored_flows` only the expected ones, it should only be concerned with sync'ing missing `OFPFC_ADD` flows (and then later on we can evolve to only keep track of the state and not the command). The consistency check still keeps deleting alien flows no changes in that part. 
2) Prior to this PR, if users were to send a `OFPFC_DELETE` that wouldn't delete any flow in the switch, the `delete` command would be stored in the `stored_flows` dict regardless, contributing to keep growing the list with a command that would be in practice not useful, and contribute to overwhelm the consistency checks. So, if a network operator needs to send a `OFPFC_DELETE` FlowMod to try to clean up other entries in the switch, or if any client of `flow_manager` misbehaves sending wrong matches, that shouldn't be something to keep track of I think, in fact, this being re-applied later with the consistency checks it could potentially delete flows that weren't supposed to, overtime this could diverge even more. `OFPFC_DELETE`(s) being treated stateless would lead to fewer surprises and more stability I think (since we are already tracking the `OFPFC_ADD(s)`). 
3) The `stored_flows` will keep growing linearly but only proportional to the number of FlowMod `OFPFC_ADD`(s) with this change, and since `OFPFC_DELETE` won't be stored anymore then the size of the list in the worst case will be as large as the switch's table, so we likely won't hit a snowball effect here that we used to have, `OFPFC_DELETE` commands weren't being ever excluded in the list, so eventually it could become massive, and it could lead to other issues because they would be re-applied in some cases. 


Let me know if you'd agree, or if you see any other potential issues, I could also break the PR in two if needed (took the chance to kill two birds with a single stone). 


