### PR TITLE
Added `black` as a dev linter dependency and formatted with it

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,32 +18,35 @@ from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 
 from .exceptions import InvalidCommandError
-from .settings import (CONSISTENCY_COOKIE_IGNORED_RANGE,
-                       CONSISTENCY_TABLE_ID_IGNORED_RANGE,
-                       ENABLE_CONSISTENCY_CHECK, FLOWS_DICT_MAX_SIZE)
+from .settings import (
+    CONSISTENCY_COOKIE_IGNORED_RANGE,
+    CONSISTENCY_TABLE_ID_IGNORED_RANGE,
+    ENABLE_CONSISTENCY_CHECK,
+    FLOWS_DICT_MAX_SIZE,
+)
 
 
 def cast_fields(flow_dict):
     """Make casting the match fields from UBInt() to native int ."""
-    match = flow_dict['match']
+    match = flow_dict["match"]
     for field, value in match.items():
         if isinstance(value, UBIntBase):
             match[field] = int(value)
-    flow_dict['match'] = match
+    flow_dict["match"] = match
     return flow_dict
 
 
 def _validate_range(values):
     """Check that the range of flows ignored by the consistency is valid."""
     if len(values) != 2:
-        msg = f'The tuple must have 2 items, not {len(values)}'
+        msg = f"The tuple must have 2 items, not {len(values)}"
         raise ValueError(msg)
     first, second = values
     if second < first:
-        msg = f'The first value is bigger than the second: {values}'
+        msg = f"The first value is bigger than the second: {values}"
         raise ValueError(msg)
     if not isinstance(first, int) or not isinstance(second, int):
-        msg = f'Expected a tuple of integers, received {values}'
+        msg = f"Expected a tuple of integers, received {values}"
         raise TypeError(msg)
 
 
@@ -54,8 +57,10 @@ def _valid_consistency_ignored(consistency_ignored_list):
     is well formatted. Returns True, if the list is well
     formatted, otherwise return False.
     """
-    msg = ('The list of ignored flows in the consistency check'
-           'is not well formatted, it will be ignored: %s')
+    msg = (
+        "The list of ignored flows in the consistency check"
+        "is not well formatted, it will be ignored: %s"
+    )
     for consistency_ignored in consistency_ignored_list:
         if isinstance(consistency_ignored, tuple):
             try:
@@ -64,8 +69,10 @@ def _valid_consistency_ignored(consistency_ignored_list):
                 log.warn(msg, error)
                 return False
         elif not isinstance(consistency_ignored, (int, tuple)):
-            error_msg = ('The elements must be of class int or tuple'
-                         f' but they are: {type(consistency_ignored)}')
+            error_msg = (
+                "The elements must be of class int or tuple"
+                f" but they are: {type(consistency_ignored)}"
+            )
             log.warn(msg, error_msg)
             return False
     return True
@@ -114,26 +121,26 @@ class Main(KytosNApp):
         """Shutdown routine of the NApp."""
         log.debug("flow-manager stopping")
 
-    @listen_to('kytos/of_core.handshake.completed')
+    @listen_to("kytos/of_core.handshake.completed")
     def resend_stored_flows(self, event):
         """Resend stored Flows."""
         # if consistency check is enabled, it should take care of this
         if ENABLE_CONSISTENCY_CHECK:
             return
-        switch = event.content['switch']
+        switch = event.content["switch"]
         dpid = str(switch.dpid)
         # This can be a problem because this code is running a thread
         if dpid in self.resent_flows:
-            log.debug(f'Flow already resent to the switch {dpid}')
+            log.debug(f"Flow already resent to the switch {dpid}")
             return
         if dpid in self.stored_flows:
-            flow_list = self.stored_flows[dpid]['flow_list']
+            flow_list = self.stored_flows[dpid]["flow_list"]
             for flow in flow_list:
-                command = flow['command']
-                flows_dict = {"flows": [flow['flow']]}
+                command = flow["command"]
+                flows_dict = {"flows": [flow["flow"]]}
                 self._install_flows(command, flows_dict, [switch])
             self.resent_flows.add(dpid)
-            log.info(f'Flows resent to Switch {dpid}')
+            log.info(f"Flows resent to Switch {dpid}")
 
     @staticmethod
     def is_ignored(field, ignored_range):
@@ -168,12 +175,12 @@ class Main(KytosNApp):
             return True
         return False
 
-    @listen_to('kytos/of_core.flow_stats.received')
+    @listen_to("kytos/of_core.flow_stats.received")
     def on_flow_stats_check_consistency(self, event):
         """Check the consistency of a switch upon receiving flow stats."""
         if not ENABLE_CONSISTENCY_CHECK:
             return
-        switch = event.content['switch']
+        switch = event.content["switch"]
         if switch.is_enabled():
             self.check_storehouse_consistency(switch)
             if switch.dpid in self.stored_flows:
@@ -184,23 +191,21 @@ class Main(KytosNApp):
         dpid = switch.dpid
 
         # Flows stored in storehouse
-        stored_flows = self.stored_flows[dpid]['flow_list']
+        stored_flows = self.stored_flows[dpid]["flow_list"]
 
         serializer = FlowFactory.get_class(switch)
 
         for stored_flow in stored_flows:
-            command = stored_flow['command']
-            stored_flow_obj = serializer.from_dict(stored_flow['flow'], switch)
+            command = stored_flow["command"]
+            stored_flow_obj = serializer.from_dict(stored_flow["flow"], switch)
 
-            flow = {'flows': [stored_flow['flow']]}
+            flow = {"flows": [stored_flow["flow"]]}
 
             if stored_flow_obj not in switch.flows:
-                if command == 'add':
-                    log.info('A consistency problem was detected in '
-                             f'switch {dpid}.')
+                if command == "add":
+                    log.info("A consistency problem was detected in " f"switch {dpid}.")
                     self._install_flows(command, flow, [switch], save=False)
-                    log.info(f'Flow forwarded to switch {dpid} to be '
-                             'installed.')
+                    log.info(f"Flow forwarded to switch {dpid} to be " "installed.")
 
     def check_storehouse_consistency(self, switch):
         """Check consistency of installed flows for a specific switch."""
@@ -213,39 +218,38 @@ class Main(KytosNApp):
                 continue
 
             if dpid not in self.stored_flows:
-                log.info('A consistency problem was detected in '
-                         f'switch {dpid}.')
-                flow = {'flows': [installed_flow.as_dict()]}
-                command = 'delete_strict'
+                log.info("A consistency problem was detected in " f"switch {dpid}.")
+                flow = {"flows": [installed_flow.as_dict()]}
+                command = "delete_strict"
                 self._install_flows(command, flow, [switch], save=False)
-                log.info(f'Flow forwarded to switch {dpid} to be deleted.')
+                log.info(f"Flow forwarded to switch {dpid} to be deleted.")
             else:
                 serializer = FlowFactory.get_class(switch)
-                stored_flows = self.stored_flows[dpid]['flow_list']
-                stored_flows_list = [serializer.from_dict(stored_flow['flow'],
-                                                          switch)
-                                     for stored_flow in stored_flows]
+                stored_flows = self.stored_flows[dpid]["flow_list"]
+                stored_flows_list = [
+                    serializer.from_dict(stored_flow["flow"], switch)
+                    for stored_flow in stored_flows
+                ]
 
                 if installed_flow not in stored_flows_list:
-                    log.info('A consistency problem was detected in '
-                             f'switch {dpid}.')
-                    flow = {'flows': [installed_flow.as_dict()]}
-                    command = 'delete_strict'
+                    log.info("A consistency problem was detected in " f"switch {dpid}.")
+                    flow = {"flows": [installed_flow.as_dict()]}
+                    command = "delete_strict"
                     self._install_flows(command, flow, [switch], save=False)
-                    log.info(f'Flow forwarded to switch {dpid} to be deleted.')
+                    log.info(f"Flow forwarded to switch {dpid} to be deleted.")
 
     # pylint: disable=attribute-defined-outside-init
     def _load_flows(self):
         """Load stored flows."""
         try:
-            data = self.storehouse.get_data()['flow_persistence']
-            if 'id' in data:
-                del data['id']
+            data = self.storehouse.get_data()["flow_persistence"]
+            if "id" in data:
+                del data["id"]
             self.stored_flows = data
         except (KeyError, FileNotFoundError) as error:
-            log.debug(f'There are no flows to load: {error}')
+            log.debug(f"There are no flows to load: {error}")
         else:
-            log.info('Flows loaded.')
+            log.info("Flows loaded.")
 
     def _store_changed_flows(self, command, flow, switch):
         """Store changed flows.
@@ -258,12 +262,14 @@ class Main(KytosNApp):
         stored_flows_box = deepcopy(self.stored_flows)
         # if the flow has a destination dpid it can be stored.
         if not switch:
-            log.info('The Flow cannot be stored, the destination switch '
-                     f'have not been specified: {switch}')
+            log.info(
+                "The Flow cannot be stored, the destination switch "
+                f"have not been specified: {switch}"
+            )
             return
         installed_flow = {}
-        installed_flow['command'] = command
-        installed_flow['flow'] = flow
+        installed_flow["command"] = command
+        installed_flow["flow"] = flow
         should_persist_flow = command == "add"
         deleted_flows_idxs = set()
 
@@ -273,31 +279,30 @@ class Main(KytosNApp):
         if switch.id not in stored_flows_box:
             # Switch not stored, add to box.
             if should_persist_flow:
-                stored_flows_box[switch.id] = {'flow_list': [installed_flow]}
+                stored_flows_box[switch.id] = {"flow_list": [installed_flow]}
         else:
-            stored_flows = stored_flows_box[switch.id].get('flow_list', [])
+            stored_flows = stored_flows_box[switch.id].get("flow_list", [])
             # Check if flow already stored
             for i, stored_flow in enumerate(stored_flows):
-                stored_flow_obj = serializer.from_dict(stored_flow['flow'],
-                                                       switch)
+                stored_flow_obj = serializer.from_dict(stored_flow["flow"], switch)
 
                 version = switch.connection.protocol.version
 
-                if installed_flow['command'] == 'delete':
+                if installed_flow["command"] == "delete":
                     # No strict match
-                    if match_flow(flow, version, stored_flow['flow']):
+                    if match_flow(flow, version, stored_flow["flow"]):
                         deleted_flows_idxs.add(i)
 
                 elif installed_flow_obj == stored_flow_obj:
-                    if stored_flow['command'] == installed_flow['command']:
-                        log.debug('Data already stored.')
+                    if stored_flow["command"] == installed_flow["command"]:
+                        log.debug("Data already stored.")
                         return
                     # Flow with inconsistency in "command" fields : Remove the
                     # old instruction. This happens when there is a stored
                     # instruction to install the flow, but the new instruction
                     # is to remove it. In this case, the old instruction is
                     # removed and the new one is stored.
-                    stored_flow['command'] = installed_flow.get('command')
+                    stored_flow["command"] = installed_flow.get("command")
                     deleted_flows_idxs.add(i)
                     break
 
@@ -309,15 +314,15 @@ class Main(KytosNApp):
                 ]
             if should_persist_flow:
                 stored_flows.append(installed_flow)
-            stored_flows_box[switch.id]['flow_list'] = stored_flows
+            stored_flows_box[switch.id]["flow_list"] = stored_flows
 
-        stored_flows_box['id'] = 'flow_persistence'
+        stored_flows_box["id"] = "flow_persistence"
         self.storehouse.save_flow(stored_flows_box)
-        del stored_flows_box['id']
+        del stored_flows_box["id"]
         self.stored_flows = deepcopy(stored_flows_box)
 
-    @rest('v2/flows')
-    @rest('v2/flows/<dpid>')
+    @rest("v2/flows")
+    @rest("v2/flows/<dpid>")
     def list(self, dpid=None):
         """Retrieve all flows from a switch identified by dpid.
 
@@ -334,30 +339,28 @@ class Main(KytosNApp):
         switch_flows = {}
 
         for switch in switches:
-            flows_dict = [cast_fields(flow.as_dict())
-                          for flow in switch.flows]
-            switch_flows[switch.dpid] = {'flows': flows_dict}
+            flows_dict = [cast_fields(flow.as_dict()) for flow in switch.flows]
+            switch_flows[switch.dpid] = {"flows": flows_dict}
 
         return jsonify(switch_flows)
 
-    @listen_to('kytos.flow_manager.flows.(install|delete)')
+    @listen_to("kytos.flow_manager.flows.(install|delete)")
     def event_flows_install_delete(self, event):
         """Install or delete flows in the switches through events.
 
         Install or delete Flow of switches identified by dpid.
         """
         try:
-            dpid = event.content['dpid']
-            flow_dict = event.content['flow_dict']
+            dpid = event.content["dpid"]
+            flow_dict = event.content["flow_dict"]
         except KeyError as error:
-            log.error("Error getting fields to install or remove "
-                      f"Flows: {error}")
+            log.error("Error getting fields to install or remove " f"Flows: {error}")
             return
 
-        if event.name == 'kytos.flow_manager.flows.install':
-            command = 'add'
-        elif event.name == 'kytos.flow_manager.flows.delete':
-            command = 'delete'
+        if event.name == "kytos.flow_manager.flows.install":
+            command = "add"
+        elif event.name == "kytos.flow_manager.flows.delete":
+            command = "delete"
         else:
             msg = f'Invalid event "{event.name}", should be install|delete'
             raise ValueError(msg)
@@ -366,11 +369,12 @@ class Main(KytosNApp):
         try:
             self._install_flows(command, flow_dict, [switch])
         except InvalidCommandError as error:
-            log.error("Error installing or deleting Flow through"
-                      f" Kytos Event: {error}")
+            log.error(
+                "Error installing or deleting Flow through" f" Kytos Event: {error}"
+            )
 
-    @rest('v2/flows', methods=['POST'])
-    @rest('v2/flows/<dpid>', methods=['POST'])
+    @rest("v2/flows", methods=["POST"])
+    @rest("v2/flows/<dpid>", methods=["POST"])
     def add(self, dpid=None):
         """Install new flows in the switch identified by dpid.
 
@@ -378,10 +382,10 @@ class Main(KytosNApp):
         """
         return self._send_flow_mods_from_request(dpid, "add")
 
-    @rest('v2/delete', methods=['POST'])
-    @rest('v2/delete/<dpid>', methods=['POST'])
-    @rest('v2/flows', methods=['DELETE'])
-    @rest('v2/flows/<dpid>', methods=['DELETE'])
+    @rest("v2/delete", methods=["POST"])
+    @rest("v2/delete/<dpid>", methods=["POST"])
+    @rest("v2/flows", methods=["DELETE"])
+    @rest("v2/flows/<dpid>", methods=["DELETE"])
     def delete(self, dpid=None):
         """Delete existing flows in the switch identified by dpid.
 
@@ -400,35 +404,36 @@ class Main(KytosNApp):
             flows_dict = request.get_json() or {}
             content_type = request.content_type
             # Get flow to check if the request is well-formed
-            flows = flows_dict.get('flows', [])
+            flows = flows_dict.get("flows", [])
 
             if content_type is None:
-                result = 'The request body is empty'
+                result = "The request body is empty"
                 raise BadRequest(result)
 
-            if content_type != 'application/json':
-                result = ('The content type must be application/json '
-                          f'(received {content_type}).')
+            if content_type != "application/json":
+                result = (
+                    "The content type must be application/json "
+                    f"(received {content_type})."
+                )
                 raise UnsupportedMediaType(result)
 
             if not any(flows_dict) or not any(flows):
-                result = 'The request body is not well-formed.'
+                result = "The request body is not well-formed."
                 raise BadRequest(result)
 
         if dpid:
             switch = self.controller.get_switch_by_dpid(dpid)
             if not switch:
-                return jsonify({"response": 'dpid not found.'}), 404
+                return jsonify({"response": "dpid not found."}), 404
             elif switch.is_enabled() is False:
                 if command == "delete":
                     self._install_flows(command, flows_dict, [switch])
                 else:
-                    return jsonify({"response": 'switch is disabled.'}), 404
+                    return jsonify({"response": "switch is disabled."}), 404
             else:
                 self._install_flows(command, flows_dict, [switch])
         else:
-            self._install_flows(command, flows_dict,
-                                self._get_all_switches_enabled())
+            self._install_flows(command, flows_dict, self._get_all_switches_enabled())
 
         return jsonify({"response": "FlowMod Messages Sent"}), 202
 
@@ -443,7 +448,7 @@ class Main(KytosNApp):
         """
         for switch in switches:
             serializer = FlowFactory.get_class(switch)
-            flows = flows_dict.get('flows', [])
+            flows = flows_dict.get("flows", [])
             for flow_dict in flows:
                 flow = serializer.from_dict(flow_dict, switch)
                 if command == "delete":
@@ -469,31 +474,29 @@ class Main(KytosNApp):
         self._flow_mods_sent[xid] = (flow, command)
 
     def _send_flow_mod(self, switch, flow_mod):
-        event_name = 'kytos/flow_manager.messages.out.ofpt_flow_mod'
+        event_name = "kytos/flow_manager.messages.out.ofpt_flow_mod"
 
-        content = {'destination': switch.connection,
-                   'message': flow_mod}
+        content = {"destination": switch.connection, "message": flow_mod}
 
         event = KytosEvent(name=event_name, content=content)
         self.controller.buffers.msg_out.put(event)
 
     def _send_napp_event(self, switch, flow, command, **kwargs):
         """Send an Event to other apps informing about a FlowMod."""
-        if command == 'add':
-            name = 'kytos/flow_manager.flow.added'
-        elif command in ('delete', 'delete_strict'):
-            name = 'kytos/flow_manager.flow.removed'
-        elif command == 'error':
-            name = 'kytos/flow_manager.flow.error'
+        if command == "add":
+            name = "kytos/flow_manager.flow.added"
+        elif command in ("delete", "delete_strict"):
+            name = "kytos/flow_manager.flow.removed"
+        elif command == "error":
+            name = "kytos/flow_manager.flow.error"
         else:
             raise InvalidCommandError
-        content = {'datapath': switch,
-                   'flow': flow}
+        content = {"datapath": switch, "flow": flow}
         content.update(kwargs)
         event_app = KytosEvent(name, content)
         self.controller.buffers.app.put(event_app)
 
-    @listen_to('.*.of_core.*.ofpt_error')
+    @listen_to(".*.of_core.*.ofpt_error")
     def handle_errors(self, event):
         """Receive OpenFlow error and send a event.
 
@@ -515,7 +518,7 @@ class Main(KytosNApp):
 
         if message.code == BadActionCode.OFPBAC_BAD_OUT_PORT:
             actions = []
-            if hasattr(error_packet, 'actions'):
+            if hasattr(error_packet, "actions"):
                 # Get actions from the flow mod (OF 1.0)
                 actions = error_packet.actions
             else:
@@ -535,6 +538,11 @@ class Main(KytosNApp):
         except KeyError:
             pass
         else:
-            self._send_napp_event(flow.switch, flow, 'error',
-                                  error_command=error_command,
-                                  error_type=error_type, error_code=error_code)
+            self._send_napp_event(
+                flow.switch,
+                flow,
+                "error",
+                error_command=error_command,
+                error_type=error_type,
+                error_code=error_code,
+            )

--- a/main.py
+++ b/main.py
@@ -19,9 +19,12 @@ from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import get_time, listen_to, now
 
 from .exceptions import InvalidCommandError
-from .settings import (CONSISTENCY_COOKIE_IGNORED_RANGE,
-                       CONSISTENCY_TABLE_ID_IGNORED_RANGE,
-                       ENABLE_CONSISTENCY_CHECK, FLOWS_DICT_MAX_SIZE)
+from .settings import (
+    CONSISTENCY_COOKIE_IGNORED_RANGE,
+    CONSISTENCY_TABLE_ID_IGNORED_RANGE,
+    ENABLE_CONSISTENCY_CHECK,
+    FLOWS_DICT_MAX_SIZE,
+)
 
 
 def cast_fields(flow_dict):
@@ -194,12 +197,11 @@ class Main(KytosNApp):
         serializer = FlowFactory.get_class(switch)
 
         for stored_flow in stored_flows:
-            stored_time = get_time(stored_flow.get('created_at',
-                                                   '0001-01-01T00:00:00'))
+            stored_time = get_time(stored_flow.get("created_at", "0001-01-01T00:00:00"))
             if (now() - stored_time).seconds <= STATS_INTERVAL:
                 continue
-            command = stored_flow['command']
-            stored_flow_obj = serializer.from_dict(stored_flow['flow'], switch)
+            command = stored_flow["command"]
+            stored_flow_obj = serializer.from_dict(stored_flow["flow"], switch)
 
             flow = {"flows": [stored_flow["flow"]]}
 
@@ -207,8 +209,10 @@ class Main(KytosNApp):
                 if command == "add":
                     log.info("A consistency problem was detected in " f"switch {dpid}.")
                     self._install_flows(command, flow, [switch], save=False)
-                    log.info(f'Flow forwarded to switch {dpid} to be '
-                             f'installed. Flow: {flow}')
+                    log.info(
+                        f"Flow forwarded to switch {dpid} to be "
+                        f"installed. Flow: {flow}"
+                    )
 
     def check_storehouse_consistency(self, switch):
         """Check consistency of installed flows for a specific switch."""
@@ -225,8 +229,9 @@ class Main(KytosNApp):
                 flow = {"flows": [installed_flow.as_dict()]}
                 command = "delete_strict"
                 self._install_flows(command, flow, [switch], save=False)
-                log.info(f'Flow forwarded to switch {dpid} to be deleted.'
-                         f' Flow: {flow}')
+                log.info(
+                    f"Flow forwarded to switch {dpid} to be deleted." f" Flow: {flow}"
+                )
             else:
                 serializer = FlowFactory.get_class(switch)
                 stored_flows = self.stored_flows[dpid]["flow_list"]
@@ -240,8 +245,10 @@ class Main(KytosNApp):
                     flow = {"flows": [installed_flow.as_dict()]}
                     command = "delete_strict"
                     self._install_flows(command, flow, [switch], save=False)
-                    log.info(f'Flow forwarded to switch {dpid} to be deleted.'
-                             f' Flow: {flow}')
+                    log.info(
+                        f"Flow forwarded to switch {dpid} to be deleted."
+                        f" Flow: {flow}"
+                    )
 
     # pylint: disable=attribute-defined-outside-init
     def _load_flows(self):
@@ -273,9 +280,9 @@ class Main(KytosNApp):
             )
             return
         installed_flow = {}
-        installed_flow['command'] = command
-        installed_flow['flow'] = flow
-        installed_flow['created_at'] = now().strftime("%Y-%m-%dT%H:%M:%S")
+        installed_flow["command"] = command
+        installed_flow["flow"] = flow
+        installed_flow["created_at"] = now().strftime("%Y-%m-%dT%H:%M:%S")
         should_persist_flow = command == "add"
         deleted_flows_idxs = set()
 
@@ -427,8 +434,10 @@ class Main(KytosNApp):
                 result = "The request body is not well-formed."
                 raise BadRequest(result)
 
-        log.info(f'Send FlowMod from request dpid: {dpid} command: {command}'
-                 f' flows_dict: {flows_dict}')
+        log.info(
+            f"Send FlowMod from request dpid: {dpid} command: {command}"
+            f" flows_dict: {flows_dict}"
+        )
         if dpid:
             switch = self.controller.get_switch_by_dpid(dpid)
             if not switch:

--- a/match.py
+++ b/match.py
@@ -18,14 +18,14 @@ def match_flow(flow_to_install, version, stored_flow_dict):
         return match10_no_strict(flow_to_install, stored_flow_dict)
     elif version == 0x04:
         return match13_no_strict(flow_to_install, stored_flow_dict)
-    raise NotImplementedError(f'Unsupported OpenFlow version {version}')
+    raise NotImplementedError(f"Unsupported OpenFlow version {version}")
 
 
 def _get_match_fields(flow_dict):
     """Generate match fields."""
     match_fields = {}
-    if 'match' in flow_dict:
-        for key, value in flow_dict['match'].items():
+    if "match" in flow_dict:
+        for key, value in flow_dict["match"].items():
             match_fields[key] = value
     return match_fields
 
@@ -33,45 +33,45 @@ def _get_match_fields(flow_dict):
 # pylint: disable=too-many-return-statements, too-many-statements, R0912
 def _match_ipv4_10(match_fields, args, wildcards):
     """Match IPV4 fields against packet with Flow (OF1.0)."""
-    if match_fields.get('dl_type') == IPV4_ETH_TYPE:
+    if match_fields.get("dl_type") == IPV4_ETH_TYPE:
         return False
-    flow_ip_int = int(ipaddress.IPv4Address(match_fields.get('nw_src', 0)))
+    flow_ip_int = int(ipaddress.IPv4Address(match_fields.get("nw_src", 0)))
     if flow_ip_int != 0:
-        mask = (wildcards
-                & FlowWildCards.OFPFW_NW_SRC_MASK) >> \
-                FlowWildCards.OFPFW_NW_SRC_SHIFT
+        mask = (
+            wildcards & FlowWildCards.OFPFW_NW_SRC_MASK
+        ) >> FlowWildCards.OFPFW_NW_SRC_SHIFT
         mask = min(mask, 32)
-        if mask != 32 and 'nw_src' not in args:
+        if mask != 32 and "nw_src" not in args:
             return False
-        mask = (0xffffffff << mask) & 0xffffffff
-        ip_int = int(ipaddress.IPv4Address(args.get('nw_src')))
+        mask = (0xFFFFFFFF << mask) & 0xFFFFFFFF
+        ip_int = int(ipaddress.IPv4Address(args.get("nw_src")))
         if ip_int & mask != flow_ip_int & mask:
             return False
-    flow_ip_int = int(ipaddress.IPv4Address(match_fields.get('nw_dst', 0)))
+    flow_ip_int = int(ipaddress.IPv4Address(match_fields.get("nw_dst", 0)))
     if flow_ip_int != 0:
-        mask = (wildcards
-                & FlowWildCards.OFPFW_NW_DST_MASK) >> \
-                FlowWildCards.OFPFW_NW_DST_SHIFT
+        mask = (
+            wildcards & FlowWildCards.OFPFW_NW_DST_MASK
+        ) >> FlowWildCards.OFPFW_NW_DST_SHIFT
         mask = min(mask, 32)
-        if mask != 32 and 'nw_dst' not in args:
+        if mask != 32 and "nw_dst" not in args:
             return False
-        mask = (0xffffffff << mask) & 0xffffffff
-        ip_int = int(ipaddress.IPv4Address(args.get('nw_dst')))
+        mask = (0xFFFFFFFF << mask) & 0xFFFFFFFF
+        ip_int = int(ipaddress.IPv4Address(args.get("nw_dst")))
         if ip_int & mask != flow_ip_int & mask:
             return False
     if not wildcards & FlowWildCards.OFPFW_NW_TOS:
-        if ('nw_tos', 'nw_proto', 'tp_src', 'tp_dst') not in args:
+        if ("nw_tos", "nw_proto", "tp_src", "tp_dst") not in args:
             return True
-        if match_fields.get('nw_tos') != int(args.get('nw_tos')):
+        if match_fields.get("nw_tos") != int(args.get("nw_tos")):
             return False
     if not wildcards & FlowWildCards.OFPFW_NW_PROTO:
-        if match_fields.get('nw_proto') != int(args.get('nw_proto')):
+        if match_fields.get("nw_proto") != int(args.get("nw_proto")):
             return False
     if not wildcards & FlowWildCards.OFPFW_TP_SRC:
-        if match_fields.get('tp_src') != int(args.get('tp_src')):
+        if match_fields.get("tp_src") != int(args.get("tp_src")):
             return False
     if not wildcards & FlowWildCards.OFPFW_TP_DST:
-        if match_fields.get('tp_dst') != int(args.get('tp_dst')):
+        if match_fields.get("tp_dst") != int(args.get("tp_dst")):
             return False
     return True
 
@@ -81,24 +81,24 @@ def match10_no_strict(flow_dict, args):
     """Match a packet against this flow (OF1.0)."""
     args = _get_match_fields(args)
     match_fields = _get_match_fields(flow_dict)
-    wildcards = match_fields.get('wildcards', 0)
+    wildcards = match_fields.get("wildcards", 0)
     if not wildcards & FlowWildCards.OFPFW_IN_PORT:
-        if match_fields.get('in_port') != args.get('in_port'):
+        if match_fields.get("in_port") != args.get("in_port"):
             return False
     if not wildcards & FlowWildCards.OFPFW_DL_VLAN_PCP:
-        if match_fields.get('dl_vlan_pcp') != args.get('dl_vlan_pcp'):
+        if match_fields.get("dl_vlan_pcp") != args.get("dl_vlan_pcp"):
             return False
     if not wildcards & FlowWildCards.OFPFW_DL_VLAN:
-        if match_fields.get('dl_vlan') != args.get('dl_vlan'):
+        if match_fields.get("dl_vlan") != args.get("dl_vlan"):
             return False
     if not wildcards & FlowWildCards.OFPFW_DL_SRC:
-        if match_fields.get('dl_src') != args.get('dl_src'):
+        if match_fields.get("dl_src") != args.get("dl_src"):
             return False
     if not wildcards & FlowWildCards.OFPFW_DL_DST:
-        if match_fields.get('dl_dst') != args.get('dl_dst'):
+        if match_fields.get("dl_dst") != args.get("dl_dst"):
             return False
     if not wildcards & FlowWildCards.OFPFW_DL_TYPE:
-        if match_fields.get('dl_type') != args.get('dl_type'):
+        if match_fields.get("dl_type") != args.get("dl_type"):
             return False
     if not _match_ipv4_10(match_fields, args, wildcards):
         return False
@@ -110,25 +110,24 @@ def match13_no_strict(flow_to_install, stored_flow_dict):
 
     Return the flow if any fields match, otherwise, return False.
     """
-    if 'match' not in flow_to_install or 'match' not in stored_flow_dict:
+    if "match" not in flow_to_install or "match" not in stored_flow_dict:
         return stored_flow_dict
-    if not flow_to_install['match']:
+    if not flow_to_install["match"]:
         return stored_flow_dict
-    if len(flow_to_install['match']) > len(stored_flow_dict['match']):
+    if len(flow_to_install["match"]) > len(stored_flow_dict["match"]):
         return False
 
-    for key, value in flow_to_install.get('match').items():
-        if key not in stored_flow_dict['match']:
+    for key, value in flow_to_install.get("match").items():
+        if key not in stored_flow_dict["match"]:
             return False
-        if value != stored_flow_dict['match'].get(key):
+        if value != stored_flow_dict["match"].get(key):
             return False
 
     key_masks = {"cookie": "cookie_mask"}
     for key, key_mask in key_masks.items():
         if flow_to_install.get(key_mask) and key in stored_flow_dict:
             value = flow_to_install[key] & flow_to_install[key_mask]
-            stored_value = (stored_flow_dict[key] &
-                            flow_to_install[key_mask])
+            stored_value = stored_flow_dict[key] & flow_to_install[key_mask]
             if value != stored_value:
                 return False
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,3 +2,4 @@
 -e git+https://github.com/kytos-ng/kytos.git#egg=kytos
 -e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
 -e .[dev]
+black>=21.10b0 # 21.x requires click>=7.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,6 +13,7 @@
     # via
     #   -r requirements/dev.in
     #   kytos
+black>=21.10b0 # via -r requirements/dev.in
 astroid==2.8.4
     # via pylint
 backcall==0.1.0
@@ -21,11 +22,12 @@ backcall==0.1.0
     #   kytos
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-click==7.1.1
+click>=7.1.2
     # via
     #   flask
     #   kytos
     #   pip-tools
+    #   black
 coverage==6.1.1
     # via kytos-flow-manager
 decorator==4.4.2

--- a/serializers/base.py
+++ b/serializers/base.py
@@ -1,8 +1,7 @@
 """Abstract class for serializing flows."""
 from abc import ABC, abstractmethod
 
-from pyof.v0x01.controller2switch.flow_mod import \
-    FlowModCommand as CommonFlowModCommand
+from pyof.v0x01.controller2switch.flow_mod import FlowModCommand as CommonFlowModCommand
 
 
 class FlowSerializer(ABC):
@@ -18,8 +17,9 @@ class FlowSerializer(ABC):
 
     def __init__(self):
         """Initialize common attributes of 1.0 and 1.3 versions."""
-        self.flow_attributes = set(('priority', 'idle_timeout', 'hard_timeout',
-                                    'cookie'))
+        self.flow_attributes = set(
+            ("priority", "idle_timeout", "hard_timeout", "cookie")
+        )
 
     @abstractmethod
     def from_dict(self, dictionary):

--- a/serializers/v0x01.py
+++ b/serializers/v0x01.py
@@ -11,16 +11,19 @@ class FlowSerializer10(FlowSerializer):
     def __init__(self):
         """Initialize OF 1.0 specific variables."""
         super().__init__()
-        self.match_attributes = set((
-            'in_port',
-            'dl_src',
-            'dl_dst',
-            'dl_type',
-            'dl_vlan',
-            'dl_vlan_pcp',
-            'nw_src',
-            'nw_dst',
-            'nw_proto'))
+        self.match_attributes = set(
+            (
+                "in_port",
+                "dl_src",
+                "dl_dst",
+                "dl_type",
+                "dl_vlan",
+                "dl_vlan_pcp",
+                "nw_src",
+                "nw_dst",
+                "nw_proto",
+            )
+        )
 
     def from_dict(self, dictionary):
         """Return an OF 1.0 FlowMod message from serialized dictionary."""
@@ -28,9 +31,9 @@ class FlowSerializer10(FlowSerializer):
         for field, data in dictionary.items():
             if field in self.flow_attributes:
                 setattr(flow_mod, field, data)
-            elif field == 'match':
+            elif field == "match":
                 self._update_match(flow_mod.match, data)
-            elif field == 'actions':
+            elif field == "actions":
                 actions = self._actions_from_list(data)
                 flow_mod.actions.extend(actions)
         return flow_mod
@@ -46,13 +49,13 @@ class FlowSerializer10(FlowSerializer):
         """Return actions found in the action list."""
         actions = []
         for action in action_list:
-            if action['action_type'] == 'set_vlan':
-                new_action = ActionVlanVid(vlan_id=action['vlan_id'])
-            elif action['action_type'] == 'output':
-                if action['port'] == 'controller':
+            if action["action_type"] == "set_vlan":
+                new_action = ActionVlanVid(vlan_id=action["vlan_id"])
+            elif action["action_type"] == "output":
+                if action["port"] == "controller":
                     new_action = ActionOutput(port=Port.OFPP_CONTROLLER)
                 else:
-                    new_action = ActionOutput(port=action['port'])
+                    new_action = ActionOutput(port=action["port"])
             else:
                 continue
             actions.append(new_action)
@@ -60,9 +63,11 @@ class FlowSerializer10(FlowSerializer):
 
     def to_dict(self, flow_stats):
         """Return a dictionary created from OF 1.0 FlowStats."""
-        flow_dict = {field: data.value
-                     for field, data in vars(flow_stats).items()
-                     if field in self.flow_attributes}
+        flow_dict = {
+            field: data.value
+            for field, data in vars(flow_stats).items()
+            if field in self.flow_attributes
+        }
 
         match_dict = {}
         for field, data in vars(flow_stats.match).items():
@@ -72,15 +77,19 @@ class FlowSerializer10(FlowSerializer):
         actions_list = []
         for action in flow_stats.actions:
             if action.action_type == ActionType.OFPAT_SET_VLAN_VID:
-                actions_list.append({'action_type': 'set_vlan',
-                                     'vlan_id': action.vlan_id.value})
+                actions_list.append(
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": action.vlan_id.value,
+                    }
+                )
             elif action.action_type == ActionType.OFPAT_OUTPUT:
                 if action.port == Port.OFPP_CONTROLLER:
-                    actions_list.append({'action_type': 'output',
-                                         'port': 'controller'})
+                    actions_list.append({"action_type": "output", "port": "controller"})
                 else:
-                    actions_list.append({'action_type': 'output',
-                                         'port': action.port.value})
+                    actions_list.append(
+                        {"action_type": "output", "port": action.port.value}
+                    )
 
-        flow_dict.update({'match': match_dict, 'actions': actions_list})
+        flow_dict.update({"match": match_dict, "actions": actions_list})
         return flow_dict

--- a/serializers/v0x04.py
+++ b/serializers/v0x04.py
@@ -4,8 +4,13 @@ from itertools import chain
 from napps.kytos.flow_manager.serializers.base import FlowSerializer
 from pyof.foundation.basic_types import HWAddress, IPAddress
 from pyof.foundation.network_types import EtherType
-from pyof.v0x04.common.action import (ActionOutput, ActionPopVLAN, ActionPush,
-                                      ActionSetField, ActionType)
+from pyof.v0x04.common.action import (
+    ActionOutput,
+    ActionPopVLAN,
+    ActionPush,
+    ActionSetField,
+    ActionType,
+)
 from pyof.v0x04.common.flow_instructions import InstructionApplyAction
 from pyof.v0x04.common.flow_instructions import InstructionType as IType
 from pyof.v0x04.common.flow_match import OxmOfbMatchField, OxmTLV, VlanId
@@ -21,15 +26,16 @@ class FlowSerializer13(FlowSerializer):
         """Initialize OF 1.3 specific variables."""
         super().__init__()
         self._match_names = {
-            'in_port': OxmOfbMatchField.OFPXMT_OFB_IN_PORT,
-            'dl_src': OxmOfbMatchField.OFPXMT_OFB_ETH_SRC,
-            'dl_dst': OxmOfbMatchField.OFPXMT_OFB_ETH_DST,
-            'dl_type': OxmOfbMatchField.OFPXMT_OFB_ETH_TYPE,
-            'dl_vlan': OxmOfbMatchField.OFPXMT_OFB_VLAN_VID,
-            'dl_vlan_pcp': OxmOfbMatchField.OFPXMT_OFB_VLAN_PCP,
-            'nw_src': OxmOfbMatchField.OFPXMT_OFB_IPV4_SRC,
-            'nw_dst': OxmOfbMatchField.OFPXMT_OFB_IPV4_DST,
-            'nw_proto': OxmOfbMatchField.OFPXMT_OFB_IP_PROTO}
+            "in_port": OxmOfbMatchField.OFPXMT_OFB_IN_PORT,
+            "dl_src": OxmOfbMatchField.OFPXMT_OFB_ETH_SRC,
+            "dl_dst": OxmOfbMatchField.OFPXMT_OFB_ETH_DST,
+            "dl_type": OxmOfbMatchField.OFPXMT_OFB_ETH_TYPE,
+            "dl_vlan": OxmOfbMatchField.OFPXMT_OFB_VLAN_VID,
+            "dl_vlan_pcp": OxmOfbMatchField.OFPXMT_OFB_VLAN_PCP,
+            "nw_src": OxmOfbMatchField.OFPXMT_OFB_IPV4_SRC,
+            "nw_dst": OxmOfbMatchField.OFPXMT_OFB_IPV4_DST,
+            "nw_proto": OxmOfbMatchField.OFPXMT_OFB_IP_PROTO,
+        }
         # Invert match_values index
         self._match_values = {b: a for a, b in self._match_names.items()}
 
@@ -42,35 +48,38 @@ class FlowSerializer13(FlowSerializer):
         for field, data in dictionary.items():
             if field in self.flow_attributes:
                 setattr(flow_mod, field, data)
-            elif field == 'match':
+            elif field == "match":
                 tlvs = self._match_from_dict(data)
                 flow_mod.match.oxm_match_fields.append(list(tlvs))
-            elif field == 'actions':
+            elif field == "actions":
                 actions = self._actions_from_list(data)
                 instruction.actions.extend(list(actions))
 
         return flow_mod
 
     def _match_from_dict(self, dictionary):
-        known_fields = ((field, data) for field, data in dictionary.items()
-                        if field in self._match_names)
+        known_fields = (
+            (field, data)
+            for field, data in dictionary.items()
+            if field in self._match_names
+        )
         for field_name, data in known_fields:
             tlv = OxmTLV()
             tlv.oxm_field = self._match_names[field_name]
             # set oxm_value
-            if field_name in ('dl_vlan_pcp', 'nw_proto'):
-                tlv.oxm_value = data.to_bytes(1, 'big')
-            elif field_name == 'dl_vlan':
+            if field_name in ("dl_vlan_pcp", "nw_proto"):
+                tlv.oxm_value = data.to_bytes(1, "big")
+            elif field_name == "dl_vlan":
                 vid = data | VlanId.OFPVID_PRESENT
-                tlv.oxm_value = vid.to_bytes(2, 'big')
-            elif field_name in ('dl_src', 'dl_dst'):
+                tlv.oxm_value = vid.to_bytes(2, "big")
+            elif field_name in ("dl_src", "dl_dst"):
                 tlv.oxm_value = HWAddress(data).pack()
-            elif field_name in ('nw_src', 'nw_dst'):
+            elif field_name in ("nw_src", "nw_dst"):
                 tlv.oxm_value = IPAddress(data).pack()
-            elif field_name == 'in_port':
-                tlv.oxm_value = data.to_bytes(4, 'big')
+            elif field_name == "in_port":
+                tlv.oxm_value = data.to_bytes(4, "big")
             else:
-                tlv.oxm_value = data.to_bytes(2, 'big')
+                tlv.oxm_value = data.to_bytes(2, "big")
             yield tlv
 
     @classmethod
@@ -82,21 +91,22 @@ class FlowSerializer13(FlowSerializer):
 
     @classmethod
     def _action_from_dict(cls, action):
-        if action['action_type'] == 'set_vlan':
-            tlv = cls._create_vlan_tlv(vlan_id=action['vlan_id'])
+        if action["action_type"] == "set_vlan":
+            tlv = cls._create_vlan_tlv(vlan_id=action["vlan_id"])
             return ActionSetField(field=tlv)
-        elif action['action_type'] == 'output':
-            if action['port'] == 'controller':
+        elif action["action_type"] == "output":
+            if action["port"] == "controller":
                 return ActionOutput(port=PortNo.OFPP_CONTROLLER)
-            return ActionOutput(port=action['port'])
-        elif action['action_type'] == 'push_vlan':
-            if action['tag_type'] == 's':
+            return ActionOutput(port=action["port"])
+        elif action["action_type"] == "push_vlan":
+            if action["tag_type"] == "s":
                 ethertype = EtherType.VLAN_QINQ
             else:
                 ethertype = EtherType.VLAN
-            return ActionPush(action_type=ActionType.OFPAT_PUSH_VLAN,
-                              ethertype=ethertype)
-        elif action['action_type'] == 'pop_vlan':
+            return ActionPush(
+                action_type=ActionType.OFPAT_PUSH_VLAN, ethertype=ethertype
+            )
+        elif action["action_type"] == "pop_vlan":
             return ActionPopVLAN()
 
     @staticmethod
@@ -104,36 +114,41 @@ class FlowSerializer13(FlowSerializer):
         tlv = OxmTLV()
         tlv.oxm_field = OxmOfbMatchField.OFPXMT_OFB_VLAN_VID
         oxm_value = vlan_id | VlanId.OFPVID_PRESENT
-        tlv.oxm_value = oxm_value.to_bytes(2, 'big')
+        tlv.oxm_value = oxm_value.to_bytes(2, "big")
         return tlv
 
     def to_dict(self, flow_stats):
         """Return a dictionary created from input 1.3 switch's flows."""
-        flow_dict = {field: data.value
-                     for field, data in vars(flow_stats).items()
-                     if field in self.flow_attributes}
-        flow_dict['match'] = self._match_to_dict(flow_stats)
-        flow_dict['actions'] = self._actions_to_list(flow_stats)
+        flow_dict = {
+            field: data.value
+            for field, data in vars(flow_stats).items()
+            if field in self.flow_attributes
+        }
+        flow_dict["match"] = self._match_to_dict(flow_stats)
+        flow_dict["actions"] = self._actions_to_list(flow_stats)
         return flow_dict
 
     def _match_to_dict(self, flow_stats):
         match_dict = {}
-        fields = (field for field in flow_stats.match.oxm_match_fields
-                  if field.oxm_field in self._match_values)
+        fields = (
+            field
+            for field in flow_stats.match.oxm_match_fields
+            if field.oxm_field in self._match_values
+        )
         for field in fields:
             match_field = self._match_values[field.oxm_field]
-            if match_field == 'dl_vlan':
-                data = int.from_bytes(field.oxm_value, 'big') & 4095
-            elif match_field in ('dl_src', 'dl_dst'):
+            if match_field == "dl_vlan":
+                data = int.from_bytes(field.oxm_value, "big") & 4095
+            elif match_field in ("dl_src", "dl_dst"):
                 addr = HWAddress()
                 addr.unpack(field.oxm_value)
                 data = str(addr)
-            elif match_field in ('nw_src', 'nw_dst'):
+            elif match_field in ("nw_src", "nw_dst"):
                 addr = IPAddress()
                 addr.unpack(field.oxm_value)
                 data = str(addr)
             else:
-                data = int.from_bytes(field.oxm_value, 'big')
+                data = int.from_bytes(field.oxm_value, "big")
             match_dict[match_field] = data
         return match_dict
 
@@ -148,25 +163,28 @@ class FlowSerializer13(FlowSerializer):
     def _action_to_dict(action):
         if action.action_type == ActionType.OFPAT_SET_FIELD:
             if action.field.oxm_field == OxmOfbMatchField.OFPXMT_OFB_VLAN_VID:
-                data = int.from_bytes(action.field.oxm_value, 'big') & 4095
-                return {'action_type': 'set_vlan', 'vlan_id': data}
+                data = int.from_bytes(action.field.oxm_value, "big") & 4095
+                return {"action_type": "set_vlan", "vlan_id": data}
         elif action.action_type == ActionType.OFPAT_OUTPUT:
             if action.port == PortNo.OFPP_CONTROLLER:
-                return {'action_type': 'output', 'port': 'controller'}
-            return {'action_type': 'output', 'port': action.port.value}
+                return {"action_type": "output", "port": "controller"}
+            return {"action_type": "output", "port": action.port.value}
         elif action.action_type == ActionType.OFPAT_PUSH_VLAN:
             if action.ethertype == EtherType.VLAN_QINQ:
-                return {'action_type': 'push_vlan', 'tag_type': 's'}
-            return {'action_type': 'push_vlan', 'tag_type': 'c'}
+                return {"action_type": "push_vlan", "tag_type": "s"}
+            return {"action_type": "push_vlan", "tag_type": "c"}
         elif action.action_type == ActionType.OFPAT_POP_VLAN:
-            return {'action_type': 'pop_vlan'}
+            return {"action_type": "pop_vlan"}
         return {}
 
     @staticmethod
     def _filter_actions(flow_stats):
         """Filter instructions and return a list of their actions."""
-        instructions = (inst for inst in flow_stats.instructions
-                        if inst.instruction_type == IType.OFPIT_APPLY_ACTIONS)
+        instructions = (
+            inst
+            for inst in flow_stats.instructions
+            if inst.instruction_type == IType.OFPIT_APPLY_ACTIONS
+        )
         action_lists = (instruction.actions for instruction in instructions)
         # Make a list from a list of lists
         return chain.from_iterable(action_lists)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,18 @@
 [pycodestyle]
+max-line-length = 88
 exclude = .eggs,ENV,build,docs/conf.py,venv
+add-ignore = D105
+# D105: Missing docstring in magic method
 
 [yala]
 radon mi args = --min C
 pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code --ignored-modules=napps.kytos.topology
 
-[pydocstyle]
-add-ignore = D105
-# D105: Missing docstring in magic method
+[flake8]
+max-line-length = 88
 
 [isort]
+profile = black
 # The first party was necessary to fix travis build.
 known_first_party = kytos,tests
 known_third_party = pyof

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,8 @@ class Linter(SimpleCommand):
     def run(self):
         """Run yala."""
         # TODO submit a PR for yala to support black as a linter
+        print("black is running. It may take some seconds...")
+        check_call("git ls-files | grep -e '.py$' | xargs black --check", shell=True)
         print("Yala is running. It may take several seconds...")
         check_call("yala setup.py *.py serializers tests", shell=True)
 

--- a/setup.py
+++ b/setup.py
@@ -17,25 +17,25 @@ from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
-if 'bdist_wheel' in sys.argv:
+if "bdist_wheel" in sys.argv:
     raise RuntimeError("This setup.py does not support wheels")
 
 # Paths setup with virtualenv detection
-BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
+BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
-NAPP_NAME = 'flow_manager'
-NAPP_VERSION = '4.1'
+NAPP_NAME = "flow_manager"
+NAPP_VERSION = "4.1"
 
 # Kytos var folder
-VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'
+VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"
 # Path for enabled NApps
-ENABLED_PATH = VAR_PATH / 'napps'
+ENABLED_PATH = VAR_PATH / "napps"
 # Path to install NApps
-INSTALLED_PATH = VAR_PATH / 'napps' / '.installed'
-CURRENT_DIR = Path('.').resolve()
+INSTALLED_PATH = VAR_PATH / "napps" / ".installed"
+CURRENT_DIR = Path(".").resolve()
 
 # NApps enabled by default
-CORE_NAPPS = ['of_core']
+CORE_NAPPS = ["of_core"]
 
 
 class SimpleCommand(Command):
@@ -62,29 +62,27 @@ class TestCommand(Command):
     """Test tags decorators."""
 
     user_options = [
-        ('size=', None, 'Specify the size of tests to be executed.'),
-        ('type=', None, 'Specify the type of tests to be executed.'),
+        ("size=", None, "Specify the size of tests to be executed."),
+        ("type=", None, "Specify the type of tests to be executed."),
     ]
 
-    sizes = ('small', 'medium', 'large', 'all')
-    types = ('unit', 'integration', 'e2e')
+    sizes = ("small", "medium", "large", "all")
+    types = ("unit", "integration", "e2e")
 
     def get_args(self):
         """Return args to be used in test command."""
-        return '--size %s --type %s' % (self.size, self.type)
+        return "--size %s --type %s" % (self.size, self.type)
 
     def initialize_options(self):
         """Set default size and type args."""
-        self.size = 'all'
-        self.type = 'unit'
+        self.size = "all"
+        self.type = "unit"
 
     def finalize_options(self):
         """Post-process."""
         try:
-            assert self.size in self.sizes, ('ERROR: Invalid size:'
-                                             f':{self.size}')
-            assert self.type in self.types, ('ERROR: Invalid type:'
-                                             f':{self.type}')
+            assert self.size in self.sizes, "ERROR: Invalid size:" f":{self.size}"
+            assert self.type in self.types, "ERROR: Invalid type:" f":{self.type}"
         except AssertionError as exc:
             print(exc)
             sys.exit(-1)
@@ -93,77 +91,77 @@ class TestCommand(Command):
 class Cleaner(SimpleCommand):
     """Custom clean command to tidy up the project root."""
 
-    description = 'clean build, dist, pyc and egg from package and docs'
+    description = "clean build, dist, pyc and egg from package and docs"
 
     def run(self):
         """Clean build, dist, pyc and egg from package and docs."""
-        call('rm -vrf ./build ./dist ./*.egg-info', shell=True)
-        call('find . -name __pycache__ -type d | xargs rm -rf', shell=True)
-        call('make -C docs/ clean', shell=True)
+        call("rm -vrf ./build ./dist ./*.egg-info", shell=True)
+        call("find . -name __pycache__ -type d | xargs rm -rf", shell=True)
+        call("make -C docs/ clean", shell=True)
 
 
 class Test(TestCommand):
     """Run all tests."""
 
-    description = 'run tests and display results'
+    description = "run tests and display results"
 
     def get_args(self):
         """Return args to be used in test command."""
         markers = self.size
         if markers == "small":
-            markers = 'not medium and not large'
+            markers = "not medium and not large"
         size_args = "" if self.size == "all" else "-m '%s'" % markers
         return '--addopts="tests/%s %s"' % (self.type, size_args)
 
     def run(self):
         """Run tests."""
-        cmd = 'python setup.py pytest %s' % self.get_args()
+        cmd = "python setup.py pytest %s" % self.get_args()
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
-            print('Unit tests failed. Fix the errors above and try again.')
+            print("Unit tests failed. Fix the errors above and try again.")
             sys.exit(-1)
 
 
 class TestCoverage(Test):
     """Display test coverage."""
 
-    description = 'run tests and display code coverage'
+    description = "run tests and display code coverage"
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = 'coverage3 run setup.py pytest %s' % self.get_args()
-        cmd += '&& coverage3 report'
+        cmd = "coverage3 run setup.py pytest %s" % self.get_args()
+        cmd += "&& coverage3 report"
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
-            print('Coverage tests failed. Fix the errors above and try again.')
+            print("Coverage tests failed. Fix the errors above and try again.")
             sys.exit(-1)
 
 
 class Linter(SimpleCommand):
     """Code linters."""
 
-    description = 'lint Python source code'
+    description = "lint Python source code"
 
     def run(self):
         """Run yala."""
-        print('Yala is running. It may take several seconds...')
-        check_call('yala setup.py *.py serializers tests', shell=True)
+        print("Yala is running. It may take several seconds...")
+        check_call("yala setup.py *.py serializers tests", shell=True)
 
 
 class CITest(TestCommand):
     """Run all CI tests."""
 
-    description = 'run all CI tests: unit and doc tests, linter'
+    description = "run all CI tests: unit and doc tests, linter"
 
     def run(self):
         """Run unit tests with coverage, doc tests and linter."""
-        coverage_cmd = 'python3.6 setup.py coverage %s' % self.get_args()
-        lint_cmd = 'python3.6 setup.py lint'
-        cmd = '%s && %s' % (coverage_cmd, lint_cmd)
+        coverage_cmd = "python3.6 setup.py coverage %s" % self.get_args()
+        lint_cmd = "python3.6 setup.py lint"
+        cmd = "%s && %s" % (coverage_cmd, lint_cmd)
         check_call(cmd, shell=True)
 
 
@@ -173,9 +171,9 @@ class KytosInstall:
     @staticmethod
     def enable_core_napps():
         """Enable a NAPP by creating a symlink."""
-        (ENABLED_PATH / 'kytos').mkdir(parents=True, exist_ok=True)
+        (ENABLED_PATH / "kytos").mkdir(parents=True, exist_ok=True)
         for napp in CORE_NAPPS:
-            napp_path = Path('kytos', napp)
+            napp_path = Path("kytos", napp)
             src = ENABLED_PATH / napp_path
             dst = INSTALLED_PATH / napp_path
             symlink_if_different(src, dst)
@@ -202,9 +200,17 @@ class EggInfo(egg_info):
     @staticmethod
     def _install_deps_wheels():
         """Python wheels are much faster (no compiling)."""
-        print('Installing dependencies...')
-        check_call([sys.executable, '-m', 'pip', 'install', '-r',
-                    'requirements/run.in'])
+        print("Installing dependencies...")
+        check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                "requirements/run.in",
+            ]
+        )
 
 
 class DevelopMode(develop):
@@ -214,7 +220,7 @@ class DevelopMode(develop):
     created on the system aiming the current source code.
     """
 
-    description = 'Install NApps in development mode'
+    description = "Install NApps in development mode"
 
     def run(self):
         """Install the package in a developer mode."""
@@ -233,21 +239,21 @@ class DevelopMode(develop):
         ./napps/kytos/napp_name will generate a link in
         var/lib/kytos/napps/.installed/kytos/napp_name.
         """
-        links = INSTALLED_PATH / 'kytos'
+        links = INSTALLED_PATH / "kytos"
         links.mkdir(parents=True, exist_ok=True)
         code = CURRENT_DIR
         src = links / NAPP_NAME
         symlink_if_different(src, code)
 
-        (ENABLED_PATH / 'kytos').mkdir(parents=True, exist_ok=True)
-        dst = ENABLED_PATH / Path('kytos', NAPP_NAME)
+        (ENABLED_PATH / "kytos").mkdir(parents=True, exist_ok=True)
+        dst = ENABLED_PATH / Path("kytos", NAPP_NAME)
         symlink_if_different(dst, src)
 
     @staticmethod
     def _create_file_symlinks():
         """Symlink to required files."""
-        src = ENABLED_PATH / '__init__.py'
-        dst = CURRENT_DIR / 'napps' / '__init__.py'
+        src = ENABLED_PATH / "__init__.py"
+        dst = CURRENT_DIR / "napps" / "__init__.py"
         symlink_if_different(src, dst)
 
 
@@ -264,38 +270,40 @@ def symlink_if_different(path, target):
         path.symlink_to(target)
 
 
-setup(name=f'kytos_{NAPP_NAME}',
-      version=NAPP_VERSION,
-      description='Core NApps developed by the Kytos Team',
-      url=f'http://github.com/kytos/{NAPP_NAME}',
-      author='Kytos Team',
-      author_email='of-ng-dev@ncc.unesp.br',
-      license='MIT',
-      install_requires=['setuptools >= 36.0.1'],
-      setup_requires=['pytest-runner'],
-      tests_require=['pytest'],
-      extras_require={
-          'dev': [
-              'coverage',
-              'pip-tools',
-              'yala',
-              'tox',
-          ],
-      },
-      cmdclass={
-          'clean': Cleaner,
-          'ci': CITest,
-          'coverage': TestCoverage,
-          'develop': DevelopMode,
-          'install': InstallMode,
-          'lint': Linter,
-          'egg_info': EggInfo,
-          'test': Test,
-      },
-      zip_safe=False,
-      classifiers=[
-          'License :: OSI Approved :: MIT License',
-          'Operating System :: POSIX :: Linux',
-          'Programming Language :: Python :: 3.6',
-          'Topic :: System :: Networking',
-      ])
+setup(
+    name=f"kytos_{NAPP_NAME}",
+    version=NAPP_VERSION,
+    description="Core NApps developed by the Kytos Team",
+    url=f"http://github.com/kytos/{NAPP_NAME}",
+    author="Kytos Team",
+    author_email="of-ng-dev@ncc.unesp.br",
+    license="MIT",
+    install_requires=["setuptools >= 36.0.1"],
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
+    extras_require={
+        "dev": [
+            "coverage",
+            "pip-tools",
+            "yala",
+            "tox",
+        ],
+    },
+    cmdclass={
+        "clean": Cleaner,
+        "ci": CITest,
+        "coverage": TestCoverage,
+        "develop": DevelopMode,
+        "install": InstallMode,
+        "lint": Linter,
+        "egg_info": EggInfo,
+        "test": Test,
+    },
+    zip_safe=False,
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: System :: Networking",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -146,8 +146,10 @@ class Linter(SimpleCommand):
 
     description = "lint Python source code"
 
+    # pylint: disable=fixme
     def run(self):
         """Run yala."""
+        # TODO submit a PR for yala to support black as a linter
         print("Yala is running. It may take several seconds...")
         check_call("yala setup.py *.py serializers tests", shell=True)
 

--- a/storehouse.py
+++ b/storehouse.py
@@ -26,11 +26,12 @@ class StoreHouse:
     def __init__(self, controller):
         """Create a storehouse client instance."""
         self.controller = controller
-        self.namespace = 'kytos.flow.persistence'
-        self.box_restore_timer = getattr(settings, 'BOX_RESTORE_TIMER',
-                                         DEFAULT_BOX_RESTORE_TIMER)
+        self.namespace = "kytos.flow.persistence"
+        self.box_restore_timer = getattr(
+            settings, "BOX_RESTORE_TIMER", DEFAULT_BOX_RESTORE_TIMER
+        )
 
-        if 'box' not in self.__dict__:
+        if "box" not in self.__dict__:
             self.box = None
         self.list_stored_boxes()
 
@@ -42,32 +43,37 @@ class StoreHouse:
             time.sleep(self.box_restore_timer)
             i += 1
         if not self.box:
-            error = 'Error retrieving persistence box from storehouse.'
+            error = "Error retrieving persistence box from storehouse."
             log.error(error)
             raise FileNotFoundError(error)
         return self.box.data
 
     def create_box(self):
         """Create a persistence box to store administrative changes."""
-        content = {'namespace': self.namespace,
-                   'callback': self._create_box_callback,
-                   'data': {}}
-        event = KytosEvent(name='kytos.storehouse.create', content=content)
+        content = {
+            "namespace": self.namespace,
+            "callback": self._create_box_callback,
+            "data": {},
+        }
+        event = KytosEvent(name="kytos.storehouse.create", content=content)
         self.controller.buffers.app.put(event)
 
     def _create_box_callback(self, _event, data, error):
         """Execute the callback to handle create_box."""
         if error:
-            log.error(f'Can\'t create persistence'
-                      f'box with namespace {self.namespace}')
+            log.error(
+                f"Can't create persistence" f"box with namespace {self.namespace}"
+            )
 
         self.box = data
 
     def list_stored_boxes(self):
         """List all persistence box stored in storehouse."""
-        name = 'kytos.storehouse.list'
-        content = {'namespace': self.namespace,
-                   'callback': self._get_or_create_a_box_from_list_of_boxes}
+        name = "kytos.storehouse.list"
+        content = {
+            "namespace": self.namespace,
+            "callback": self._get_or_create_a_box_from_list_of_boxes,
+        }
 
         event = KytosEvent(name=name, content=content)
         self.controller.buffers.app.put(event)
@@ -81,35 +87,39 @@ class StoreHouse:
 
     def get_stored_box(self, box_id):
         """Get persistence box from storehouse."""
-        content = {'namespace': self.namespace,
-                   'callback': self._get_box_callback,
-                   'box_id': box_id,
-                   'data': {}}
-        name = 'kytos.storehouse.retrieve'
+        content = {
+            "namespace": self.namespace,
+            "callback": self._get_box_callback,
+            "box_id": box_id,
+            "data": {},
+        }
+        name = "kytos.storehouse.retrieve"
         event = KytosEvent(name=name, content=content)
         self.controller.buffers.app.put(event)
 
     def _get_box_callback(self, _event, data, error):
         """Handle get_box method saving the box or logging with the error."""
         if error:
-            log.error('Persistence box not found.')
+            log.error("Persistence box not found.")
 
         self.box = data
 
     def save_flow(self, flows):
         """Save flows in storehouse."""
-        self.box.data[flows['id']] = flows
-        content = {'namespace': self.namespace,
-                   'box_id': self.box.box_id,
-                   'data': self.box.data,
-                   'callback': self._save_flow_callback}
+        self.box.data[flows["id"]] = flows
+        content = {
+            "namespace": self.namespace,
+            "box_id": self.box.box_id,
+            "data": self.box.data,
+            "callback": self._save_flow_callback,
+        }
 
-        event = KytosEvent(name='kytos.storehouse.update', content=content)
+        event = KytosEvent(name="kytos.storehouse.update", content=content)
         self.controller.buffers.app.put(event)
 
     def _save_flow_callback(self, _event, data, error):
         """Display stored flow."""
         if error:
-            log.error(f'Can\'t update persistence box {data.box_id}.')
+            log.error(f"Can't update persistence box {data.box_id}.")
 
-        log.info(f'Flow saved in {self.namespace}.{data.box_id}')
+        log.info(f"Flow saved in {self.namespace}.{data.box_id}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,11 +3,11 @@ import os
 import sys
 from pathlib import Path
 
-if 'VIRTUAL_ENV' in os.environ:
-    BASE_ENV = Path(os.environ['VIRTUAL_ENV'])
+if "VIRTUAL_ENV" in os.environ:
+    BASE_ENV = Path(os.environ["VIRTUAL_ENV"])
 else:
-    BASE_ENV = Path('/')
+    BASE_ENV = Path("/")
 
-NAPPS_PATH = BASE_ENV / '/var/lib/kytos/'
+NAPPS_PATH = BASE_ENV / "/var/lib/kytos/"
 
 sys.path.insert(0, str(NAPPS_PATH))

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -11,14 +11,13 @@ class TestMain(TestCase):
     """Test the Main class."""
 
     def setUp(self):
-        """Execute steps before each tests.
-        """
+        """Execute steps before each tests."""
         self.napp = Main(self.get_controller_mock())
 
     @staticmethod
     def get_controller_mock():
         """Return a controller mock."""
-        options = KytosConfig().options['daemon']
+        options = KytosConfig().options["daemon"]
         controller = Controller(options)
         controller.log = Mock()
         return controller
@@ -26,7 +25,7 @@ class TestMain(TestCase):
     def test_add_flow_mod_sent_ok(self):
         self.napp._flow_mods_sent_max_size = 3
         flow = Mock()
-        xid = '12345'
+        xid = "12345"
         initial_len = len(self.napp._flow_mods_sent)
         self.napp._add_flow_mod_sent(xid, flow)
 
@@ -35,13 +34,13 @@ class TestMain(TestCase):
 
     def test_add_flow_mod_sent_overlimit(self):
         self.napp._flow_mods_sent_max_size = 5
-        xid = '23456'
+        xid = "23456"
         while len(self.napp._flow_mods_sent) < 5:
-            xid += '1'
+            xid += "1"
             flow = Mock()
             self.napp._add_flow_mod_sent(xid, flow)
 
-        xid = '90876'
+        xid = "90876"
         flow = Mock()
         initial_len = len(self.napp._flow_mods_sent)
         self.napp._add_flow_mod_sent(xid, flow)

--- a/tests/unit/test_flow_serializer_v0x01.py
+++ b/tests/unit/test_flow_serializer_v0x01.py
@@ -13,8 +13,8 @@ class TestFlowSerializer10(TestCase):
         """Execute steps before each tests."""
         self.napp = FlowSerializer10()
 
-    @patch('napps.kytos.flow_manager.serializers.v0x01.ActionOutput')
-    @patch('napps.kytos.flow_manager.serializers.v0x01.FlowMod')
+    @patch("napps.kytos.flow_manager.serializers.v0x01.ActionOutput")
+    @patch("napps.kytos.flow_manager.serializers.v0x01.FlowMod")
     def test_from_dict(self, *args):
         """Test from_dict method."""
         (mock_flow_mod, _) = args
@@ -22,75 +22,86 @@ class TestFlowSerializer10(TestCase):
         flow_mod.actions = []
         mock_flow_mod.return_value = flow_mod
 
-        self.napp.flow_attributes = {'flow_attr'}
-        self.napp.match_attributes = {'match_attr'}
-        dictionary = {'flow_attr': 'any_data',
-                      'match': {'match_attr': 122},
-                      'actions': [{'action_type': 'output',
-                                   'port': 'controller'}]}
+        self.napp.flow_attributes = {"flow_attr"}
+        self.napp.match_attributes = {"match_attr"}
+        dictionary = {
+            "flow_attr": "any_data",
+            "match": {"match_attr": 122},
+            "actions": [{"action_type": "output", "port": "controller"}],
+        }
         return_flow_mod = self.napp.from_dict(dictionary)
 
-        self.assertEqual(return_flow_mod.flow_attr, 'any_data')
+        self.assertEqual(return_flow_mod.flow_attr, "any_data")
         self.assertEqual(return_flow_mod.match.match_attr, 122)
         self.assertEqual(len(return_flow_mod.actions), 1)
 
     def test_update_match(self):
         """Test _update_match method."""
         match = MagicMock()
-        dictionary = {'attr': 'data'}
-        self.napp.match_attributes = {'attr'}
+        dictionary = {"attr": "data"}
+        self.napp.match_attributes = {"attr"}
 
         self.napp._update_match(match, dictionary)
 
-        self.assertEqual(match.attr, 'data')
+        self.assertEqual(match.attr, "data")
 
-    @patch('napps.kytos.flow_manager.serializers.v0x01.ActionOutput')
-    @patch('napps.kytos.flow_manager.serializers.v0x01.ActionVlanVid')
+    @patch("napps.kytos.flow_manager.serializers.v0x01.ActionOutput")
+    @patch("napps.kytos.flow_manager.serializers.v0x01.ActionVlanVid")
     def test_actions_from_list(self, *args):
         """Test _actions_from_list method."""
         (mock_action_vlan_vid, mock_action_output) = args
-        mock_action_vlan_vid.return_value = 'action_vlan_vid'
-        mock_action_output.side_effect = ['action_output_controller',
-                                          'action_output_any']
-        actions = [{'action_type': 'set_vlan', 'vlan_id': 'id'},
-                   {'action_type': 'output', 'port': 'controller'},
-                   {'action_type': 'output', 'port': 'any'},
-                   {'action_type': 'any'}]
+        mock_action_vlan_vid.return_value = "action_vlan_vid"
+        mock_action_output.side_effect = [
+            "action_output_controller",
+            "action_output_any",
+        ]
+        actions = [
+            {"action_type": "set_vlan", "vlan_id": "id"},
+            {"action_type": "output", "port": "controller"},
+            {"action_type": "output", "port": "any"},
+            {"action_type": "any"},
+        ]
 
         return_actions = self.napp._actions_from_list(actions)
 
-        expected_actions = ['action_vlan_vid', 'action_output_controller',
-                            'action_output_any']
+        expected_actions = [
+            "action_vlan_vid",
+            "action_output_controller",
+            "action_output_any",
+        ]
         self.assertEqual(return_actions, expected_actions)
 
     def test_to_dict(self):
         """Test to_dict method."""
         action_1 = MagicMock()
         action_1.action_type = 1
-        action_1.vlan_id.value = 'id'
+        action_1.vlan_id.value = "id"
 
         action_2 = MagicMock()
         action_2.action_type = 0
-        action_2.port = 0xfffd
+        action_2.port = 0xFFFD
 
         action_3 = MagicMock()
         action_3.action_type = 0
-        action_3.port.value = 'port'
+        action_3.port.value = "port"
 
         flow_stats = MagicMock()
         flow_stats.actions = [action_1, action_2, action_3]
         flow_stats.flow_attr = MagicMock()
         flow_stats.match.match_attr = MagicMock()
-        self.napp.flow_attributes = {'flow_attr'}
-        self.napp.match_attributes = {'match_attr'}
+        self.napp.flow_attributes = {"flow_attr"}
+        self.napp.match_attributes = {"match_attr"}
 
         flow_dict = self.napp.to_dict(flow_stats)
 
-        expected = {'flow_attr': flow_stats.flow_attr.value,
-                    'match': {'match_attr': flow_stats.match.match_attr.value},
-                    'actions': [{'action_type': 'set_vlan', 'vlan_id': 'id'},
-                                {'action_type': 'output',
-                                 'port': 'controller'},
-                                {'action_type': 'output', 'port': 'port'}]}
+        expected = {
+            "flow_attr": flow_stats.flow_attr.value,
+            "match": {"match_attr": flow_stats.match.match_attr.value},
+            "actions": [
+                {"action_type": "set_vlan", "vlan_id": "id"},
+                {"action_type": "output", "port": "controller"},
+                {"action_type": "output", "port": "port"},
+            ],
+        }
 
         self.assertEqual(flow_dict, expected)

--- a/tests/unit/test_flow_serializer_v0x04.py
+++ b/tests/unit/test_flow_serializer_v0x04.py
@@ -13,10 +13,10 @@ class TestFlowSerializer13(TestCase):
         """Execute steps before each tests."""
         self.napp = FlowSerializer13()
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.ActionOutput')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.OxmTLV')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.InstructionApplyAction')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.FlowMod')
+    @patch("napps.kytos.flow_manager.serializers.v0x04.ActionOutput")
+    @patch("napps.kytos.flow_manager.serializers.v0x04.OxmTLV")
+    @patch("napps.kytos.flow_manager.serializers.v0x04.InstructionApplyAction")
+    @patch("napps.kytos.flow_manager.serializers.v0x04.FlowMod")
     def test_from_dict(self, *args):
         """Test from_dict method."""
         (mock_flow_mod, mock_instruction, _, _) = args
@@ -29,130 +29,159 @@ class TestFlowSerializer13(TestCase):
         mock_flow_mod.return_value = flow_mod
         mock_instruction.return_value = instruction
 
-        self.napp.flow_attributes = {'flow_attr'}
-        self.napp._match_names = {'match_attr': 123}
-        dictionary = {'flow_attr': 'any_data',
-                      'match': {'match_attr': 123},
-                      'actions': [{'action_type': 'output',
-                                   'port': 'controller'}]}
+        self.napp.flow_attributes = {"flow_attr"}
+        self.napp._match_names = {"match_attr": 123}
+        dictionary = {
+            "flow_attr": "any_data",
+            "match": {"match_attr": 123},
+            "actions": [{"action_type": "output", "port": "controller"}],
+        }
         return_flow_mod = self.napp.from_dict(dictionary)
 
-        self.assertEqual(return_flow_mod.flow_attr, 'any_data')
+        self.assertEqual(return_flow_mod.flow_attr, "any_data")
         self.assertEqual(len(return_flow_mod.match.oxm_match_fields), 1)
         self.assertEqual(len(return_flow_mod.instructions), 1)
         self.assertEqual(len(return_flow_mod.instructions[0].actions), 1)
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.IPAddress')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.HWAddress')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.OxmTLV')
+    @patch("napps.kytos.flow_manager.serializers.v0x04.IPAddress")
+    @patch("napps.kytos.flow_manager.serializers.v0x04.HWAddress")
+    @patch("napps.kytos.flow_manager.serializers.v0x04.OxmTLV")
     def test_match_from_dict(self, *args):
         """Test _match_from_dict method."""
         (_, mock_hw_address, mock_ip_address) = args
         hw_address = MagicMock()
-        hw_address.pack.return_value = 'hw_address'
+        hw_address.pack.return_value = "hw_address"
         mock_hw_address.return_value = hw_address
         ip_address = MagicMock()
-        ip_address.pack.return_value = 'ip_address'
+        ip_address.pack.return_value = "ip_address"
         mock_ip_address.return_value = ip_address
 
-        dictionary = {'dl_vlan_pcp': 0, 'nw_proto': 1, 'dl_vlan': 2,
-                      'dl_src': 3, 'dl_dst': 4, 'nw_src': 5, 'nw_dst': 6,
-                      'in_port': 7, 'dl_type': 8}
+        dictionary = {
+            "dl_vlan_pcp": 0,
+            "nw_proto": 1,
+            "dl_vlan": 2,
+            "dl_src": 3,
+            "dl_dst": 4,
+            "nw_src": 5,
+            "nw_dst": 6,
+            "in_port": 7,
+            "dl_type": 8,
+        }
 
         tlv_generator = self.napp._match_from_dict(dictionary)
 
-        self.assertEqual(next(tlv_generator).oxm_value, b'\x00')
-        self.assertEqual(next(tlv_generator).oxm_value, b'\x01')
-        self.assertEqual(next(tlv_generator).oxm_value, b'\x10\x02')
-        self.assertEqual(next(tlv_generator).oxm_value, 'hw_address')
-        self.assertEqual(next(tlv_generator).oxm_value, 'hw_address')
-        self.assertEqual(next(tlv_generator).oxm_value, 'ip_address')
-        self.assertEqual(next(tlv_generator).oxm_value, 'ip_address')
-        self.assertEqual(next(tlv_generator).oxm_value, b'\x00\x00\x00\x07')
-        self.assertEqual(next(tlv_generator).oxm_value, b'\x00\x08')
+        self.assertEqual(next(tlv_generator).oxm_value, b"\x00")
+        self.assertEqual(next(tlv_generator).oxm_value, b"\x01")
+        self.assertEqual(next(tlv_generator).oxm_value, b"\x10\x02")
+        self.assertEqual(next(tlv_generator).oxm_value, "hw_address")
+        self.assertEqual(next(tlv_generator).oxm_value, "hw_address")
+        self.assertEqual(next(tlv_generator).oxm_value, "ip_address")
+        self.assertEqual(next(tlv_generator).oxm_value, "ip_address")
+        self.assertEqual(next(tlv_generator).oxm_value, b"\x00\x00\x00\x07")
+        self.assertEqual(next(tlv_generator).oxm_value, b"\x00\x08")
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.ActionOutput')
+    @patch("napps.kytos.flow_manager.serializers.v0x04.ActionOutput")
     def test_actions_from_list(self, mock_action_output):
         """Test _actions_from_list method."""
-        actions = [{'action_type': 'output', 'port': 'controller'}]
+        actions = [{"action_type": "output", "port": "controller"}]
         generator = self.napp._actions_from_list(actions)
         return_action = next(generator)
 
         self.assertEqual(return_action, mock_action_output.return_value)
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.ActionPopVLAN',
-           return_value='action_pop_vlan')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.ActionPush',
-           return_value='action_push')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.ActionOutput',
-           return_value='action_output')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.ActionSetField',
-           return_value='action_set_field')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.OxmTLV')
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.ActionPopVLAN",
+        return_value="action_pop_vlan",
+    )
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.ActionPush",
+        return_value="action_push",
+    )
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.ActionOutput",
+        return_value="action_output",
+    )
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.ActionSetField",
+        return_value="action_set_field",
+    )
+    @patch("napps.kytos.flow_manager.serializers.v0x04.OxmTLV")
     def test_action_from_dict(self, *args):
         """Test _action_from_dict method."""
-        (mock_oxm_tlv, mock_action_set_field, mock_action_output,
-         mock_action_push, _) = args
+        (
+            mock_oxm_tlv,
+            mock_action_set_field,
+            mock_action_output,
+            mock_action_push,
+            _,
+        ) = args
         oxm_tlv = MagicMock()
         mock_oxm_tlv.return_value = oxm_tlv
 
-        action_1 = {'action_type': 'set_vlan', 'vlan_id': 123}
+        action_1 = {"action_type": "set_vlan", "vlan_id": 123}
         return_1 = self.napp._action_from_dict(action_1)
         mock_action_set_field.assert_called_with(field=oxm_tlv)
-        self.assertEqual(return_1, 'action_set_field')
+        self.assertEqual(return_1, "action_set_field")
 
-        action_2 = {'action_type': 'output', 'port': 'controller'}
+        action_2 = {"action_type": "output", "port": "controller"}
         return_2 = self.napp._action_from_dict(action_2)
-        mock_action_output.assert_called_with(port=0xfffffffd)
-        self.assertEqual(return_2, 'action_output')
+        mock_action_output.assert_called_with(port=0xFFFFFFFD)
+        self.assertEqual(return_2, "action_output")
 
-        action_3 = {'action_type': 'output', 'port': 'any'}
+        action_3 = {"action_type": "output", "port": "any"}
         return_3 = self.napp._action_from_dict(action_3)
-        mock_action_output.assert_called_with(port='any')
-        self.assertEqual(return_3, 'action_output')
+        mock_action_output.assert_called_with(port="any")
+        self.assertEqual(return_3, "action_output")
 
-        action_4 = {'action_type': 'push_vlan', 'tag_type': 's'}
+        action_4 = {"action_type": "push_vlan", "tag_type": "s"}
         return_4 = self.napp._action_from_dict(action_4)
-        mock_action_push.assert_called_with(action_type=17, ethertype=0x88a8)
-        self.assertEqual(return_4, 'action_push')
+        mock_action_push.assert_called_with(action_type=17, ethertype=0x88A8)
+        self.assertEqual(return_4, "action_push")
 
-        action_5 = {'action_type': 'push_vlan', 'tag_type': 'c'}
+        action_5 = {"action_type": "push_vlan", "tag_type": "c"}
         return_5 = self.napp._action_from_dict(action_5)
         mock_action_push.assert_called_with(action_type=17, ethertype=0x8100)
-        self.assertEqual(return_5, 'action_push')
+        self.assertEqual(return_5, "action_push")
 
-        action_6 = {'action_type': 'pop_vlan'}
+        action_6 = {"action_type": "pop_vlan"}
         return_6 = self.napp._action_from_dict(action_6)
-        self.assertEqual(return_6, 'action_pop_vlan')
+        self.assertEqual(return_6, "action_pop_vlan")
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.OxmTLV')
+    @patch("napps.kytos.flow_manager.serializers.v0x04.OxmTLV")
     def test_create_vlan_tlv(self, mock_oxm_tlv):
         """Test _create_vlan_tlv method."""
         tlv = self.napp._create_vlan_tlv(1)
 
         self.assertEqual(tlv.oxm_field, 6)
-        self.assertEqual(tlv.oxm_value, b'\x10\x01')
+        self.assertEqual(tlv.oxm_value, b"\x10\x01")
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.FlowSerializer13.'
-           '_actions_to_list', return_value='actions_to_list')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.FlowSerializer13.'
-           '_match_to_dict', return_value='match_to_dict')
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.FlowSerializer13."
+        "_actions_to_list",
+        return_value="actions_to_list",
+    )
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.FlowSerializer13." "_match_to_dict",
+        return_value="match_to_dict",
+    )
     def test_to_dict(self, *args):
         """Test to_dict method."""
         (_, _) = args
         flow_stats = MagicMock()
         flow_stats.flow_attr = MagicMock()
-        self.napp.flow_attributes = {'flow_attr'}
+        self.napp.flow_attributes = {"flow_attr"}
 
         flow_dict = self.napp.to_dict(flow_stats)
 
-        expected = {'flow_attr': flow_stats.flow_attr.value,
-                    'match': 'match_to_dict',
-                    'actions': 'actions_to_list'}
+        expected = {
+            "flow_attr": flow_stats.flow_attr.value,
+            "match": "match_to_dict",
+            "actions": "actions_to_list",
+        }
         self.assertEqual(flow_dict, expected)
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.HWAddress')
-    @patch('napps.kytos.flow_manager.serializers.v0x04.IPAddress')
+    @patch("napps.kytos.flow_manager.serializers.v0x04.HWAddress")
+    @patch("napps.kytos.flow_manager.serializers.v0x04.IPAddress")
     def test_match_to_dict(self, *args):
         """Test _match_to_dict method."""
         (mock_ip_address, mock_hw_address) = args
@@ -169,25 +198,31 @@ class TestFlowSerializer13(TestCase):
             flow_stats.match.oxm_match_fields.append(field)
 
         match_dict = self.napp._match_to_dict(flow_stats)
-        expected = {'in_port': 0, 'dl_vlan': 0, 'dl_src': str(hw_address),
-                    'dl_dst': str(hw_address), 'nw_src': str(ip_address),
-                    'nw_dst': str(ip_address)}
+        expected = {
+            "in_port": 0,
+            "dl_vlan": 0,
+            "dl_src": str(hw_address),
+            "dl_dst": str(hw_address),
+            "nw_src": str(ip_address),
+            "nw_dst": str(ip_address),
+        }
 
         self.assertEqual(match_dict, expected)
 
-    @patch('napps.kytos.flow_manager.serializers.v0x04.FlowSerializer13.'
-           '_filter_actions')
+    @patch(
+        "napps.kytos.flow_manager.serializers.v0x04.FlowSerializer13." "_filter_actions"
+    )
     def test_actions_to_list(self, mock_filter_actions):
         """Test _actions_to_list method."""
         flow_stats = MagicMock()
         action = MagicMock()
         action.action_type = 0
-        action.port = 0xfffffffd
+        action.port = 0xFFFFFFFD
         mock_filter_actions.return_value = [action]
 
         actions_list = self.napp._actions_to_list(flow_stats)
 
-        expected = [{'action_type': 'output', 'port': 'controller'}]
+        expected = [{"action_type": "output", "port": "controller"}]
         self.assertEqual(actions_list, expected)
 
     def test_action_to_dict(self):
@@ -195,47 +230,47 @@ class TestFlowSerializer13(TestCase):
         action_1 = MagicMock()
         action_1.action_type = 25
         action_1.field.oxm_field = 6
-        action_1.field.oxm_value = b'\x01'
+        action_1.field.oxm_value = b"\x01"
         return_1 = self.napp._action_to_dict(action_1)
-        expected = {'action_type': 'set_vlan', 'vlan_id': 1}
+        expected = {"action_type": "set_vlan", "vlan_id": 1}
         self.assertEqual(return_1, expected)
 
         action_2 = MagicMock()
         action_2.action_type = 0
-        action_2.port = 0xfffffffd
+        action_2.port = 0xFFFFFFFD
         return_2 = self.napp._action_to_dict(action_2)
-        expected = {'action_type': 'output', 'port': 'controller'}
+        expected = {"action_type": "output", "port": "controller"}
         self.assertEqual(return_2, expected)
 
         action_3 = MagicMock()
         action_3.action_type = 0
-        action_3.port.value = 'any'
+        action_3.port.value = "any"
         return_3 = self.napp._action_to_dict(action_3)
-        expected = {'action_type': 'output', 'port': 'any'}
+        expected = {"action_type": "output", "port": "any"}
         self.assertEqual(return_3, expected)
 
         action_4 = MagicMock()
         action_4.action_type = 17
-        action_4.ethertype = 0x88a8
+        action_4.ethertype = 0x88A8
         return_4 = self.napp._action_to_dict(action_4)
-        expected = {'action_type': 'push_vlan', 'tag_type': 's'}
+        expected = {"action_type": "push_vlan", "tag_type": "s"}
         self.assertEqual(return_4, expected)
 
         action_5 = MagicMock()
         action_5.action_type = 17
-        action_5.ethertype = 'any'
+        action_5.ethertype = "any"
         return_5 = self.napp._action_to_dict(action_5)
-        expected = {'action_type': 'push_vlan', 'tag_type': 'c'}
+        expected = {"action_type": "push_vlan", "tag_type": "c"}
         self.assertEqual(return_5, expected)
 
         action_6 = MagicMock()
         action_6.action_type = 18
         return_6 = self.napp._action_to_dict(action_6)
-        expected = {'action_type': 'pop_vlan'}
+        expected = {"action_type": "pop_vlan"}
         self.assertEqual(return_6, expected)
 
         action_7 = MagicMock()
-        action_7.action_type = 'any'
+        action_7.action_type = "any"
         return_7 = self.napp._action_to_dict(action_7)
         self.assertEqual(return_7, {})
 
@@ -243,7 +278,7 @@ class TestFlowSerializer13(TestCase):
         """Test _filter_actions method."""
         action = MagicMock()
         action.action_type = 0
-        action.port = 0xfffffffd
+        action.port = 0xFFFFFFFD
         instruction = MagicMock()
         instruction.instruction_type = 4
         instruction.actions = [action]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,9 +3,13 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from kytos.core.helpers import now
-from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
-                               get_kytos_event_mock, get_switch_mock,
-                               get_test_client)
+from kytos.lib.helpers import (
+    get_connection_mock,
+    get_controller_mock,
+    get_kytos_event_mock,
+    get_switch_mock,
+    get_test_client,
+)
 
 
 # pylint: disable=protected-access, too-many-public-methods
@@ -429,8 +433,8 @@ class TestMain(TestCase):
         self.napp.check_switch_consistency(switch)
         mock_install_flows.assert_not_called()
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_check_switch_consistency_ignore(self, *args):
         """Test check_switch_consistency method.
 
@@ -444,12 +448,15 @@ class TestMain(TestCase):
         switch.flows = []
 
         flow_1 = MagicMock()
-        flow_1.as_dict.return_value = {'flow_1': 'data'}
+        flow_1.as_dict.return_value = {"flow_1": "data"}
 
-        flow_list = [{"command": "add",
-                      "created_at": now().strftime("%Y-%m-%dT%H:%M:%S"),
-                      "flow": {'flow_1': 'data'}
-                      }]
+        flow_list = [
+            {
+                "command": "add",
+                "created_at": now().strftime("%Y-%m-%dT%H:%M:%S"),
+                "flow": {"flow_1": "data"},
+            }
+        ]
         serializer = MagicMock()
         serializer.flow.cookie.return_value = 0
 
@@ -458,8 +465,8 @@ class TestMain(TestCase):
         self.napp.check_switch_consistency(switch)
         mock_install_flows.assert_not_called()
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_check_storehouse_consistency(self, *args):
         """Test check_storehouse_consistency method.
 
@@ -514,8 +521,7 @@ class TestMain(TestCase):
 
         self.napp._store_changed_flows(command, flow_to_install, switch)
         mock_save_flow.assert_called()
-        self.assertDictEqual(self.napp.stored_flows[dpid]["flow_list"][0],
-                             stored_flow)
+        self.assertDictEqual(self.napp.stored_flows[dpid]["flow_list"][0], stored_flow)
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,19 +2,23 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kytos.lib.helpers import (get_connection_mock, get_controller_mock,
-                               get_kytos_event_mock, get_switch_mock,
-                               get_test_client)
+from kytos.lib.helpers import (
+    get_connection_mock,
+    get_controller_mock,
+    get_kytos_event_mock,
+    get_switch_mock,
+    get_test_client,
+)
 
 
 # pylint: disable=protected-access, too-many-public-methods
 class TestMain(TestCase):
     """Tests for the Main class."""
 
-    API_URL = 'http://localhost:8181/api/kytos/flow_manager'
+    API_URL = "http://localhost:8181/api/kytos/flow_manager"
 
     def setUp(self):
-        patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        patch("kytos.core.helpers.run_on_thread", lambda x: x).start()
         # pylint: disable=import-outside-toplevel
         from napps.kytos.flow_manager.main import Main
 
@@ -29,8 +33,10 @@ class TestMain(TestCase):
         self.switch_02.is_enabled.return_value = False
         self.switch_02.flows = []
 
-        controller.switches = {"00:00:00:00:00:00:00:01": self.switch_01,
-                               "00:00:00:00:00:00:00:02": self.switch_02}
+        controller.switches = {
+            "00:00:00:00:00:00:00:01": self.switch_01,
+            "00:00:00:00:00:00:00:02": self.switch_02,
+        }
 
         self.napp = Main(controller)
 
@@ -56,12 +62,12 @@ class TestMain(TestCase):
         self.switch_02.flows.append(flow_2)
 
         api = get_test_client(self.napp.controller, self.napp)
-        url = f'{self.API_URL}/v2/flows'
+        url = f"{self.API_URL}/v2/flows"
 
         response = api.get(url)
         expected = {
-            '00:00:00:00:00:00:00:01': {'flows': [flow_dict]},
-            '00:00:00:00:00:00:00:02': {'flows': [flow_dict_2]},
+            "00:00:00:00:00:00:00:01": {"flows": [flow_dict]},
+            "00:00:00:00:00:00:00:02": {"flows": [flow_dict_2]},
         }
         self.assertEqual(response.json, expected)
         self.assertEqual(response.status_code, 200)
@@ -79,10 +85,10 @@ class TestMain(TestCase):
         self.switch_01.flows.append(flow_1)
 
         api = get_test_client(self.napp.controller, self.napp)
-        url = f'{self.API_URL}/v2/flows/00:00:00:00:00:00:00:01'
+        url = f"{self.API_URL}/v2/flows/00:00:00:00:00:00:00:01"
 
         response = api.get(url)
-        expected = {'00:00:00:00:00:00:00:01': {'flows': [flow_dict]}}
+        expected = {"00:00:00:00:00:00:00:01": {"flows": [flow_dict]}}
 
         self.assertEqual(response.json, expected)
         self.assertEqual(response.status_code, 200)
@@ -93,19 +99,19 @@ class TestMain(TestCase):
         Failure case: Switch not found.
         """
         api = get_test_client(self.napp.controller, self.napp)
-        url = f'{self.API_URL}/v2/flows/00:00:00:00:00:00:00:05'
+        url = f"{self.API_URL}/v2/flows/00:00:00:00:00:00:00:05"
         response = api.get(url)
         self.assertEqual(response.status_code, 404)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_rest_add_and_delete_without_dpid(self, mock_install_flows):
         """Test add and delete rest method without dpid."""
         api = get_test_client(self.napp.controller, self.napp)
 
-        for method in ['flows', 'delete']:
-            url = f'{self.API_URL}/v2/{method}'
+        for method in ["flows", "delete"]:
+            url = f"{self.API_URL}/v2/{method}"
 
-            response_1 = api.post(url, json={'flows': [{"priority": 25}]})
+            response_1 = api.post(url, json={"flows": [{"priority": 25}]})
             response_2 = api.post(url)
 
             self.assertEqual(response_1.status_code, 202)
@@ -113,33 +119,33 @@ class TestMain(TestCase):
 
         self.assertEqual(mock_install_flows.call_count, 2)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_rest_add_and_delete_with_dpid(self, mock_install_flows):
         """Test add and delete rest method with dpid."""
         api = get_test_client(self.napp.controller, self.napp)
-        data = {'flows': [{"priority": 25}]}
-        for method in ['flows', 'delete']:
-            url_1 = f'{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:01'
-            url_2 = f'{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:02'
+        data = {"flows": [{"priority": 25}]}
+        for method in ["flows", "delete"]:
+            url_1 = f"{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:01"
+            url_2 = f"{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:02"
 
             response_1 = api.post(url_1, json=data)
             response_2 = api.post(url_2, json=data)
 
             self.assertEqual(response_1.status_code, 202)
-            if method == 'delete':
+            if method == "delete":
                 self.assertEqual(response_2.status_code, 202)
 
         self.assertEqual(mock_install_flows.call_count, 3)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_rest_add_and_delete_with_dpi_fail(self, mock_install_flows):
         """Test fail case the add and delete rest method with dpid."""
         api = get_test_client(self.napp.controller, self.napp)
-        data = {'flows': [{"priority": 25}]}
-        for method in ['flows', 'delete']:
-            url_1 = f'{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:01'
-            url_2 = f'{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:02'
-            url_3 = f'{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:03'
+        data = {"flows": [{"priority": 25}]}
+        for method in ["flows", "delete"]:
+            url_1 = f"{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:01"
+            url_2 = f"{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:02"
+            url_3 = f"{self.API_URL}/v2/{method}/00:00:00:00:00:00:00:03"
 
             response_1 = api.post(url_1)
             response_2 = api.post(url_2, data=data)
@@ -159,15 +165,20 @@ class TestMain(TestCase):
 
         self.assertEqual(switches, [self.switch_01])
 
-    @patch('napps.kytos.flow_manager.main.Main._store_changed_flows')
-    @patch('napps.kytos.flow_manager.main.Main._send_napp_event')
-    @patch('napps.kytos.flow_manager.main.Main._add_flow_mod_sent')
-    @patch('napps.kytos.flow_manager.main.Main._send_flow_mod')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._store_changed_flows")
+    @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
+    @patch("napps.kytos.flow_manager.main.Main._add_flow_mod_sent")
+    @patch("napps.kytos.flow_manager.main.Main._send_flow_mod")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_install_flows(self, *args):
         """Test _install_flows method."""
-        (mock_flow_factory, mock_send_flow_mod, mock_add_flow_mod_sent,
-         mock_send_napp_event, _) = args
+        (
+            mock_flow_factory,
+            mock_send_flow_mod,
+            mock_add_flow_mod_sent,
+            mock_send_napp_event,
+            _,
+        ) = args
         serializer = MagicMock()
         flow = MagicMock()
         flow_mod = MagicMock()
@@ -176,24 +187,28 @@ class TestMain(TestCase):
         serializer.from_dict.return_value = flow
         mock_flow_factory.return_value = serializer
 
-        flows_dict = {'flows': [MagicMock()]}
+        flows_dict = {"flows": [MagicMock()]}
         switches = [self.switch_01]
-        self.napp._install_flows('add', flows_dict, switches)
+        self.napp._install_flows("add", flows_dict, switches)
 
         mock_send_flow_mod.assert_called_with(flow.switch, flow_mod)
-        mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid,
-                                                  flow, 'add')
-        mock_send_napp_event.assert_called_with(self.switch_01, flow, 'add')
+        mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid, flow, "add")
+        mock_send_napp_event.assert_called_with(self.switch_01, flow, "add")
 
-    @patch('napps.kytos.flow_manager.main.Main._store_changed_flows')
-    @patch('napps.kytos.flow_manager.main.Main._send_napp_event')
-    @patch('napps.kytos.flow_manager.main.Main._add_flow_mod_sent')
-    @patch('napps.kytos.flow_manager.main.Main._send_flow_mod')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._store_changed_flows")
+    @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
+    @patch("napps.kytos.flow_manager.main.Main._add_flow_mod_sent")
+    @patch("napps.kytos.flow_manager.main.Main._send_flow_mod")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_install_flows_with_delete_strict(self, *args):
         """Test _install_flows method with strict delete command."""
-        (mock_flow_factory, mock_send_flow_mod, mock_add_flow_mod_sent,
-         mock_send_napp_event, _) = args
+        (
+            mock_flow_factory,
+            mock_send_flow_mod,
+            mock_add_flow_mod_sent,
+            mock_send_napp_event,
+            _,
+        ) = args
         serializer = MagicMock()
         flow = MagicMock()
         flow_mod = MagicMock()
@@ -202,53 +217,54 @@ class TestMain(TestCase):
         serializer.from_dict.return_value = flow
         mock_flow_factory.return_value = serializer
 
-        flows_dict = {'flows': [MagicMock()]}
+        flows_dict = {"flows": [MagicMock()]}
         switches = [self.switch_01]
-        self.napp._install_flows('delete_strict', flows_dict, switches)
+        self.napp._install_flows("delete_strict", flows_dict, switches)
 
         mock_send_flow_mod.assert_called_with(flow.switch, flow_mod)
-        mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid,
-                                                  flow, 'delete_strict')
-        mock_send_napp_event.assert_called_with(self.switch_01, flow,
-                                                'delete_strict')
+        mock_add_flow_mod_sent.assert_called_with(
+            flow_mod.header.xid, flow, "delete_strict"
+        )
+        mock_send_napp_event.assert_called_with(self.switch_01, flow, "delete_strict")
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_event_add_flow(self, mock_install_flows):
         """Test method for installing flows on the switches through events."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
         self.napp.controller.switches = {dpid: switch}
         mock_flow_dict = MagicMock()
-        event = get_kytos_event_mock(name='kytos.flow_manager.flows.install',
-                                     content={'dpid': dpid,
-                                              'flow_dict': mock_flow_dict})
+        event = get_kytos_event_mock(
+            name="kytos.flow_manager.flows.install",
+            content={"dpid": dpid, "flow_dict": mock_flow_dict},
+        )
         self.napp.event_flows_install_delete(event)
-        mock_install_flows.assert_called_with('add', mock_flow_dict, [switch])
+        mock_install_flows.assert_called_with("add", mock_flow_dict, [switch])
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_event_flows_install_delete(self, mock_install_flows):
         """Test method for removing flows on the switches through events."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
         self.napp.controller.switches = {dpid: switch}
         mock_flow_dict = MagicMock()
-        event = get_kytos_event_mock(name='kytos.flow_manager.flows.delete',
-                                     content={'dpid': dpid,
-                                              'flow_dict': mock_flow_dict})
+        event = get_kytos_event_mock(
+            name="kytos.flow_manager.flows.delete",
+            content={"dpid": dpid, "flow_dict": mock_flow_dict},
+        )
         self.napp.event_flows_install_delete(event)
-        mock_install_flows.assert_called_with('delete', mock_flow_dict,
-                                              [switch])
+        mock_install_flows.assert_called_with("delete", mock_flow_dict, [switch])
 
     def test_add_flow_mod_sent(self):
         """Test _add_flow_mod_sent method."""
         xid = 0
         flow = MagicMock()
 
-        self.napp._add_flow_mod_sent(xid, flow, 'add')
+        self.napp._add_flow_mod_sent(xid, flow, "add")
 
-        self.assertEqual(self.napp._flow_mods_sent[xid], (flow, 'add'))
+        self.assertEqual(self.napp._flow_mods_sent[xid], (flow, "add"))
 
-    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    @patch("kytos.core.buffers.KytosEventBuffer.put")
     def test_send_flow_mod(self, mock_buffers_put):
         """Test _send_flow_mod method."""
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
@@ -258,29 +274,30 @@ class TestMain(TestCase):
 
         mock_buffers_put.assert_called()
 
-    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    @patch("kytos.core.buffers.KytosEventBuffer.put")
     def test_send_napp_event(self, mock_buffers_put):
         """Test _send_napp_event method."""
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
         flow = MagicMock()
 
-        for command in ['add', 'delete', 'delete_strict', 'error']:
+        for command in ["add", "delete", "delete_strict", "error"]:
             self.napp._send_napp_event(switch, flow, command)
 
         self.assertEqual(mock_buffers_put.call_count, 4)
 
-    @patch('napps.kytos.flow_manager.main.Main._send_napp_event')
+    @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
     def test_handle_errors(self, mock_send_napp_event):
         """Test handle_errors method."""
         flow = MagicMock()
-        self.napp._flow_mods_sent[0] = (flow, 'add')
+        self.napp._flow_mods_sent[0] = (flow, "add")
 
         switch = get_switch_mock("00:00:00:00:00:00:00:01")
         switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02"))
+            0x04, get_switch_mock("00:00:00:00:00:00:00:02")
+        )
 
         protocol = MagicMock()
-        protocol.unpack.return_value = 'error_packet'
+        protocol.unpack.return_value = "error_packet"
 
         switch.connection.protocol = protocol
 
@@ -288,14 +305,20 @@ class TestMain(TestCase):
         message.header.xid.value = 0
         message.error_type = 2
         message.code = 5
-        event = get_kytos_event_mock(name='.*.of_core.*.ofpt_error',
-                                     content={'message': message,
-                                              'source': switch.connection})
+        event = get_kytos_event_mock(
+            name=".*.of_core.*.ofpt_error",
+            content={"message": message, "source": switch.connection},
+        )
         self.napp.handle_errors(event)
 
-        mock_send_napp_event.assert_called_with(flow.switch, flow, 'error',
-                                                error_command='add',
-                                                error_code=5, error_type=2)
+        mock_send_napp_event.assert_called_with(
+            flow.switch,
+            flow,
+            "error",
+            error_command="add",
+            error_code=5,
+            error_type=2,
+        )
 
     @patch("napps.kytos.flow_manager.main.StoreHouse.get_data")
     def test_load_flows(self, mock_storehouse):
@@ -343,8 +366,11 @@ class TestMain(TestCase):
         command = "add"
         flow_list = {
             "flow_list": [
-                {"match_fields": match_fields, "command": "delete",
-                 "flow": flow}
+                {
+                    "match_fields": match_fields,
+                    "command": "delete",
+                    "flow": flow,
+                }
             ]
         }
         self.napp.stored_flows = {dpid: flow_list}
@@ -355,8 +381,8 @@ class TestMain(TestCase):
         self.napp._store_changed_flows(command, flows, switch)
         mock_save_flow.assert_called()
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_check_switch_consistency_add(self, *args):
         """Test check_switch_consistency method.
 
@@ -369,11 +395,9 @@ class TestMain(TestCase):
         switch.flows = []
 
         flow_1 = MagicMock()
-        flow_1.as_dict.return_value = {'flow_1': 'data'}
+        flow_1.as_dict.return_value = {"flow_1": "data"}
 
-        flow_list = [{"command": "add",
-                      "flow": {'flow_1': 'data'}
-                      }]
+        flow_list = [{"command": "add", "flow": {"flow_1": "data"}}]
         serializer = MagicMock()
         serializer.flow.cookie.return_value = 0
 
@@ -382,8 +406,8 @@ class TestMain(TestCase):
         self.napp.check_switch_consistency(switch)
         mock_install_flows.assert_called()
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_check_switch_consistency_delete(self, *args):
         """Test check_switch_consistency method.
 
@@ -395,11 +419,9 @@ class TestMain(TestCase):
         switch = get_switch_mock(dpid, 0x04)
 
         flow_1 = MagicMock()
-        flow_1.as_dict.return_value = {'flow_1': 'data'}
+        flow_1.as_dict.return_value = {"flow_1": "data"}
 
-        flow_list = [{"command": "delete",
-                      "flow": {'flow_1': 'data'}
-                      }]
+        flow_list = [{"command": "delete", "flow": {"flow_1": "data"}}]
         serializer = MagicMock()
         serializer.from_dict.return_value = flow_1
 
@@ -410,27 +432,25 @@ class TestMain(TestCase):
         self.napp.check_switch_consistency(switch)
         mock_install_flows.assert_not_called()
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_check_storehouse_consistency(self, *args):
         """Test check_storehouse_consistency method.
 
         This test checks the case when a flow is missing in storehouse.
         """
         (mock_flow_factory, mock_install_flows) = args
-        cookie_exception_interval = [(0x2b00000000000011, 0x2b000000000000ff)]
+        cookie_exception_interval = [(0x2B00000000000011, 0x2B000000000000FF)]
         self.napp.cookie_exception_range = cookie_exception_interval
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
         flow_1 = MagicMock()
-        flow_1.cookie = 0x2b00000000000010
-        flow_1.as_dict.return_value = {'flow_1': 'data', 'cookie': 1}
+        flow_1.cookie = 0x2B00000000000010
+        flow_1.as_dict.return_value = {"flow_1": "data", "cookie": 1}
 
         switch.flows = [flow_1]
 
-        flow_list = [{"command": "add",
-                      "flow": {'flow_2': 'data', 'cookie': 1}
-                      }]
+        flow_list = [{"command": "add", "flow": {"flow_2": "data", "cookie": 1}}]
         serializer = flow_1
 
         mock_flow_factory.return_value = serializer
@@ -438,8 +458,8 @@ class TestMain(TestCase):
         self.napp.check_storehouse_consistency(switch)
         mock_install_flows.assert_called()
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     @patch("napps.kytos.flow_manager.main.StoreHouse.save_flow")
     def test_no_strict_delete(self, *args):
         """Test the non-strict matching method.
@@ -478,8 +498,8 @@ class TestMain(TestCase):
         mock_save_flow.assert_called()
         self.assertEqual(len(self.napp.stored_flows), 1)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     @patch("napps.kytos.flow_manager.main.StoreHouse.save_flow")
     def test_no_strict_delete_with_ipv4(self, *args):
         """Test the non-strict matching method.
@@ -510,7 +530,7 @@ class TestMain(TestCase):
                 "match": {"in_port": 2},
             },
         }
-        flow_to_install = {"match": {"ipv4_src": '192.168.1.1'}}
+        flow_to_install = {"match": {"ipv4_src": "192.168.1.1"}}
         flow_list = {"flow_list": [stored_flow, stored_flow2]}
         command = "delete"
         self.napp.stored_flows = {dpid: flow_list}
@@ -518,21 +538,21 @@ class TestMain(TestCase):
         self.napp._store_changed_flows(command, flow_to_install, switch)
         mock_save_flow.assert_called()
         expected_stored = {
-          "flow_list": [
-            {
-                "command": "add",
-                "flow": {
-                    "actions": [],
-                    "cookie": 4961162389751548787,
-                    "match": {"in_port": 2},
-                },
-            }
-          ]
+            "flow_list": [
+                {
+                    "command": "add",
+                    "flow": {
+                        "actions": [],
+                        "cookie": 4961162389751548787,
+                        "match": {"in_port": 2},
+                    },
+                }
+            ]
         }
         self.assertDictEqual(self.napp.stored_flows[dpid], expected_stored)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     @patch("napps.kytos.flow_manager.main.StoreHouse.save_flow")
     def test_no_strict_delete_in_port(self, *args):
         """Test the non-strict matching method.
@@ -544,39 +564,41 @@ class TestMain(TestCase):
         switch = get_switch_mock(dpid, 0x04)
         switch.id = dpid
         flow_to_install = {"match": {"in_port": 1}}
-        stored_flow = {"flow_list": [
-            {
-                "command": "add",
-                "flow": {
-                    "priority": 10,
-                    "cookie": 84114904,
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 100,
+        stored_flow = {
+            "flow_list": [
+                {
+                    "command": "add",
+                    "flow": {
+                        "priority": 10,
+                        "cookie": 84114904,
+                        "match": {
+                            "in_port": 1,
+                            "dl_vlan": 100,
+                        },
+                        "actions": [],
                     },
-                    "actions": [],
                 },
-            },
-            {
-                "command": "add",
-                "flow": {
-                    "actions": [],
-                    "match": {"in_port": 2},
-                },
-            },
-            {
-                "command": "add",
-                "flow": {
-                    "priority": 20,
-                    "cookie": 84114904,
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 102,
+                {
+                    "command": "add",
+                    "flow": {
+                        "actions": [],
+                        "match": {"in_port": 2},
                     },
-                    "actions": [],
                 },
-            },
-        ]}
+                {
+                    "command": "add",
+                    "flow": {
+                        "priority": 20,
+                        "cookie": 84114904,
+                        "match": {
+                            "in_port": 1,
+                            "dl_vlan": 102,
+                        },
+                        "actions": [],
+                    },
+                },
+            ]
+        }
         command = "delete"
         self.napp.stored_flows = {dpid: stored_flow}
 
@@ -584,22 +606,17 @@ class TestMain(TestCase):
         mock_save_flow.assert_called()
 
         expected_stored = {
-          "flow_list": [
-            {
-              "command": "add",
-              "flow": {
-                "actions": [],
-                "match": {
-                  "in_port": 2
+            "flow_list": [
+                {
+                    "command": "add",
+                    "flow": {"actions": [], "match": {"in_port": 2}},
                 }
-              }
-            }
-          ]
+            ]
         }
         self.assertDictEqual(self.napp.stored_flows[dpid], expected_stored)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     @patch("napps.kytos.flow_manager.main.StoreHouse.save_flow")
     def test_no_strict_delete_all_if_empty_match(self, *args):
         """Test the non-strict matching method.
@@ -611,32 +628,34 @@ class TestMain(TestCase):
         switch = get_switch_mock(dpid, 0x04)
         switch.id = dpid
         flow_to_install = {"match": {}}
-        stored_flow = {"flow_list": [
-            {
-                "command": "add",
-                "flow": {
-                    "priority": 10,
-                    "cookie": 84114904,
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 100,
+        stored_flow = {
+            "flow_list": [
+                {
+                    "command": "add",
+                    "flow": {
+                        "priority": 10,
+                        "cookie": 84114904,
+                        "match": {
+                            "in_port": 1,
+                            "dl_vlan": 100,
+                        },
+                        "actions": [],
                     },
-                    "actions": [],
                 },
-            },
-            {
-                "command": "add",
-                "flow": {
-                    "priority": 20,
-                    "cookie": 84114904,
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 102,
+                {
+                    "command": "add",
+                    "flow": {
+                        "priority": 20,
+                        "cookie": 84114904,
+                        "match": {
+                            "in_port": 1,
+                            "dl_vlan": 102,
+                        },
+                        "actions": [],
                     },
-                    "actions": [],
                 },
-            },
-        ]}
+            ]
+        }
         command = "delete"
         self.napp.stored_flows = {dpid: stored_flow}
 
@@ -646,8 +665,8 @@ class TestMain(TestCase):
         expected_stored = {"flow_list": []}
         self.assertDictEqual(self.napp.stored_flows[dpid], expected_stored)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     @patch("napps.kytos.flow_manager.main.StoreHouse.save_flow")
     def test_no_strict_delete_with_ipv4_fail(self, *args):
         """Test the non-strict matching method.
@@ -678,7 +697,7 @@ class TestMain(TestCase):
                 "match": {"in_port": 2},
             },
         }
-        flow_to_install = {"match": {"ipv4_src": '192.168.20.20'}}
+        flow_to_install = {"match": {"ipv4_src": "192.168.20.20"}}
         flow_list = {"flow_list": [stored_flow, stored_flow2]}
         command = "delete"
         self.napp.stored_flows = {dpid: flow_list}
@@ -686,33 +705,33 @@ class TestMain(TestCase):
         self.napp._store_changed_flows(command, flow_to_install, switch)
         mock_save_flow.assert_called()
         expected_stored = {
-          "flow_list": [
-            {
-                "command": "add",
-                "flow": {
-                    "priority": 10,
-                    "cookie": 84114904,
-                    "match": {
-                        "ipv4_src": "192.168.2.1",
-                        "ipv4_dst": "192.168.0.2",
+            "flow_list": [
+                {
+                    "command": "add",
+                    "flow": {
+                        "priority": 10,
+                        "cookie": 84114904,
+                        "match": {
+                            "ipv4_src": "192.168.2.1",
+                            "ipv4_dst": "192.168.0.2",
+                        },
+                        "actions": [],
                     },
-                    "actions": [],
                 },
-            },
-            {
-                "command": "add",
-                "flow": {
-                    "actions": [],
-                    "cookie": 4961162389751548787,
-                    "match": {"in_port": 2},
+                {
+                    "command": "add",
+                    "flow": {
+                        "actions": [],
+                        "cookie": 4961162389751548787,
+                        "match": {"in_port": 2},
+                    },
                 },
-            }
-          ]
+            ]
         }
         self.assertDictEqual(self.napp.stored_flows[dpid], expected_stored)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     @patch("napps.kytos.flow_manager.main.StoreHouse.save_flow")
     def test_no_strict_delete_of10(self, *args):
         """Test the non-strict matching method.
@@ -776,39 +795,42 @@ class TestMain(TestCase):
 
         self.napp._store_changed_flows(command, flow_to_install, switch)
         mock_save_flow.assert_called()
-        self.assertEqual(len(self.napp.stored_flows[dpid]['flow_list']), 0)
+        self.assertEqual(len(self.napp.stored_flows[dpid]["flow_list"]), 0)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_consistency_cookie_ignored_range(self, *args):
         """Test the consistency `cookie` ignored range."""
         (mock_flow_factory, mock_install_flows) = args
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
-        cookie_ignored_interval = [(0x2b00000000000011,
-                                    0x2b000000000000ff), 0x2b00000000000100]
+        cookie_ignored_interval = [
+            (0x2B00000000000011, 0x2B000000000000FF),
+            0x2B00000000000100,
+        ]
         self.napp.cookie_ignored_range = cookie_ignored_interval
         flow = MagicMock()
         expected = [
-                    {'cookie': 0x2b00000000000010, 'called': 1},
-                    {'cookie': 0x2b00000000000013, 'called': 0},
-                    {'cookie': 0x2b00000000000100, 'called': 0},
-                    {'cookie': 0x2b00000000000101, 'called': 1}]
+            {"cookie": 0x2B00000000000010, "called": 1},
+            {"cookie": 0x2B00000000000013, "called": 0},
+            {"cookie": 0x2B00000000000100, "called": 0},
+            {"cookie": 0x2B00000000000101, "called": 1},
+        ]
         # ignored flow
         for i in expected:
             mock_install_flows.call_count = 0
-            cookie = i['cookie']
-            called = i['called']
+            cookie = i["cookie"]
+            called = i["called"]
             flow.cookie = cookie
-            flow.as_dict.return_value = {'flow_1': 'data', 'cookie': cookie}
+            flow.as_dict.return_value = {"flow_1": "data", "cookie": cookie}
             switch.flows = [flow]
             mock_flow_factory.return_value = flow
             self.napp.stored_flows = {dpid: {"flow_list": flow}}
             self.napp.check_storehouse_consistency(switch)
             self.assertEqual(mock_install_flows.call_count, called)
 
-    @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_consistency_table_id_ignored_range(self, *args):
         """Test the consistency `table_id` ignored range."""
         (mock_flow_factory, mock_install_flows) = args
@@ -818,16 +840,17 @@ class TestMain(TestCase):
         self.napp.tab_id_ignored_range = table_id_ignored_interval
         flow = MagicMock()
         expected = [
-                    {'table_id': 0, 'called': 1},
-                    {'table_id': 3, 'called': 0},
-                    {'table_id': 4, 'called': 1}]
+            {"table_id": 0, "called": 1},
+            {"table_id": 3, "called": 0},
+            {"table_id": 4, "called": 1},
+        ]
         # ignored flow
         for i in expected:
-            table_id = i['table_id']
-            called = i['called']
+            table_id = i["table_id"]
+            called = i["called"]
             mock_install_flows.call_count = 0
             flow.table_id = table_id
-            flow.as_dict.return_value = {'flow_1': 'data', 'cookie': table_id}
+            flow.as_dict.return_value = {"flow_1": "data", "cookie": table_id}
             switch.flows = [flow]
             mock_flow_factory.return_value = flow
             self.napp.stored_flows = {dpid: {"flow_list": flow}}

--- a/tests/unit/test_storehouse.py
+++ b/tests/unit/test_storehouse.py
@@ -14,16 +14,17 @@ class TestStoreHouse(TestCase):
 
         Set the server_name_url_url from kytos/flow_manager
         """
-        self.server_name_url = 'http://localhost:8181/api/kytos/flow_manager'
+        self.server_name_url = "http://localhost:8181/api/kytos/flow_manager"
 
-        patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        patch("kytos.core.helpers.run_on_thread", lambda x: x).start()
         # pylint: disable=import-outside-toplevel
         from napps.kytos.flow_manager.storehouse import StoreHouse
+
         self.addCleanup(patch.stopall)
 
         self.napp = StoreHouse(get_controller_mock())
 
-    @patch('napps.kytos.flow_manager.storehouse.StoreHouse.get_stored_box')
+    @patch("napps.kytos.flow_manager.storehouse.StoreHouse.get_stored_box")
     def test_get_data(self, mock_get_stored_box):
         """Test get_data."""
         mock_box = MagicMock()
@@ -38,8 +39,8 @@ class TestStoreHouse(TestCase):
         response = self.napp.get_data()
         self.assertEqual(response.data, "box")
 
-    @patch('napps.kytos.flow_manager.storehouse.KytosEvent')
-    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    @patch("napps.kytos.flow_manager.storehouse.KytosEvent")
+    @patch("kytos.core.buffers.KytosEventBuffer.put")
     def test_create_box(self, *args):
         """Test create_box."""
         (mock_buffers_put, mock_event) = args
@@ -48,25 +49,23 @@ class TestStoreHouse(TestCase):
         mock_buffers_put.assert_called()
 
     # pylint: disable = protected-access
-    @patch('napps.kytos.flow_manager.storehouse.StoreHouse.get_stored_box')
-    @patch('napps.kytos.flow_manager.storehouse.StoreHouse.create_box')
+    @patch("napps.kytos.flow_manager.storehouse.StoreHouse.get_stored_box")
+    @patch("napps.kytos.flow_manager.storehouse.StoreHouse.create_box")
     def test_get_or_create_a_box_from_list_of_boxes(self, *args):
         """Test create_box."""
         (mock_create_box, mock_get_stored_box) = args
         mock_event = MagicMock()
         mock_data = MagicMock()
         mock_error = MagicMock()
-        self.napp._get_or_create_a_box_from_list_of_boxes(mock_event,
-                                                          mock_data,
-                                                          mock_error)
+        self.napp._get_or_create_a_box_from_list_of_boxes(
+            mock_event, mock_data, mock_error
+        )
         mock_get_stored_box.assert_called()
-        self.napp._get_or_create_a_box_from_list_of_boxes(mock_event,
-                                                          None,
-                                                          mock_error)
+        self.napp._get_or_create_a_box_from_list_of_boxes(mock_event, None, mock_error)
         mock_create_box.assert_called()
 
-    @patch('napps.kytos.flow_manager.storehouse.KytosEvent')
-    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    @patch("napps.kytos.flow_manager.storehouse.KytosEvent")
+    @patch("kytos.core.buffers.KytosEventBuffer.put")
     def test_get_stored_box(self, *args):
         """Test get_stored_box."""
         (mock_buffers_put, mock_event) = args
@@ -75,8 +74,8 @@ class TestStoreHouse(TestCase):
         mock_event.assert_called()
         mock_buffers_put.assert_called()
 
-    @patch('napps.kytos.flow_manager.storehouse.KytosEvent')
-    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    @patch("napps.kytos.flow_manager.storehouse.KytosEvent")
+    @patch("kytos.core.buffers.KytosEventBuffer.put")
     def test_save_flow(self, *args):
         """Test save_status."""
         (mock_buffers_put, mock_event) = args


### PR DESCRIPTION
I have some upcoming fixes for flow_manager that we have planned, and to minimize code formatting changes as the team has agreed, I'm sending a prior prior just related to enabling and formatting the code with [`black`](https://github.com/psf/black). I'll document in this PR how it can be introduced on other NApps as well, and then in the future we can evolve setting up pre-commit hooks as well: 

## How to add `black` as a linter on NApps

- Add it as a dependency on `requirements/dev.in` (we'll try to get it as a linter on `yala` upstream), and make sure that the `Linter.run()` method on `setup.py` is also passing the python files to be check, see f19131ae28451cf9b311ba8652ab81115a319800
- Make sure to update `setup.cfg` file accordingly that `yala` uses, just so `isort` plays nicely with `black`, it needs the `black` profile, and also both `flake8` and `pycodestyle` need to update the `max-line-length = 88`, see 91dc33ed9e6c1cd25b1c5276104411d18d912c77
- If you need to run locally since we don't have a pre-commit yet, `git ls-files | grep -e '.py$' | xargs black` , or you can integrate with your text editor to run `black` on save or based on a shortcut. 

## Execution on CI

- Until `black` is also part of `yala`, the output on CI should look like this, if any python file under git weren't formatted by `black` it would stop the execution with the name of the file that needs to be formatted: 

```
lint run-test-pre: PYTHONHASHSEED='1863339192'
lint run-test: commands[0] | python setup.py lint
running lint
black is running. It may take some seconds...
All done! ✨ 🍰 ✨
18 files would be left unchanged.
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished pylint
[isort] Skipped 5 files
:) No issues found.
```

**Heads up**:

- This PR is on top of PR #36 (so that needs to land first)
- Also this PR depends on [`kytos/core` PR 142](https://github.com/kytos-ng/kytos/pull/142), to get some of the general fixes plus the `click` bumped minor version `click>=7.1.1`