### PR TITLE
[Fix] Handle error when switch is not connected

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -3,3 +3,7 @@
 
 class InvalidCommandError(Exception):
     """Command has an invalid value."""
+
+
+class SwitchNotConnectedError(Exception):
+    """Exception raised when a switch's connection isn't connected."""

--- a/main.py
+++ b/main.py
@@ -16,9 +16,9 @@ from pyof.v0x01.asynchronous.error_msg import BadActionCode
 from pyof.v0x01.common.phy_port import PortConfig
 from werkzeug.exceptions import (
     BadRequest,
+    FailedDependency,
     NotFound,
     UnsupportedMediaType,
-    FailedDependency,
 )
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
@@ -572,8 +572,8 @@ class Main(KytosNApp):
             self._install_flows(command, flows_dict, [switch])
             return jsonify({"response": "FlowMod Messages Sent"}), 202
 
-        except SwitchNotConnectedError as e:
-            raise FailedDependency(str(e))
+        except SwitchNotConnectedError as error:
+            raise FailedDependency(str(error))
 
     def _install_flows(self, command, flows_dict, switches=[], save=True):
         """Execute all procedures to install flows in the switches.

--- a/main.py
+++ b/main.py
@@ -14,12 +14,17 @@ from napps.kytos.of_core.settings import STATS_INTERVAL
 from pyof.foundation.base import UBIntBase
 from pyof.v0x01.asynchronous.error_msg import BadActionCode
 from pyof.v0x01.common.phy_port import PortConfig
-from werkzeug.exceptions import BadRequest, NotFound, UnsupportedMediaType
+from werkzeug.exceptions import (
+    BadRequest,
+    NotFound,
+    UnsupportedMediaType,
+    FailedDependency,
+)
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import get_time, listen_to, now
 
-from .exceptions import InvalidCommandError
+from .exceptions import InvalidCommandError, SwitchNotConnectedError
 from .settings import (
     ARCHIVED_MAX_FLOWS_PER_SWITCH,
     ARCHIVED_ROTATION_DELETED,
@@ -550,21 +555,25 @@ class Main(KytosNApp):
             f"Send FlowMod from request dpid: {dpid} command: {command}"
             f" flows_dict: {flows_dict}"
         )
-        if dpid:
+        try:
+            if not dpid:
+                self._install_flows(
+                    command, flows_dict, self._get_all_switches_enabled()
+                )
+                return jsonify({"response": "FlowMod Messages Sent"}), 202
+
             switch = self.controller.get_switch_by_dpid(dpid)
             if not switch:
                 return jsonify({"response": "dpid not found."}), 404
-            elif switch.is_enabled() is False:
-                if command == "delete":
-                    self._install_flows(command, flows_dict, [switch])
-                else:
-                    return jsonify({"response": "switch is disabled."}), 404
-            else:
-                self._install_flows(command, flows_dict, [switch])
-        else:
-            self._install_flows(command, flows_dict, self._get_all_switches_enabled())
 
-        return jsonify({"response": "FlowMod Messages Sent"}), 202
+            if not switch.is_enabled() and command == "add":
+                return jsonify({"response": "switch is disabled."}), 404
+
+            self._install_flows(command, flows_dict, [switch])
+            return jsonify({"response": "FlowMod Messages Sent"}), 202
+
+        except SwitchNotConnectedError as e:
+            raise FailedDependency(str(e))
 
     def _install_flows(self, command, flows_dict, switches=[], save=True):
         """Execute all procedures to install flows in the switches.
@@ -603,8 +612,10 @@ class Main(KytosNApp):
         self._flow_mods_sent[xid] = (flow, command)
 
     def _send_flow_mod(self, switch, flow_mod):
-        event_name = "kytos/flow_manager.messages.out.ofpt_flow_mod"
+        if not switch.is_connected():
+            raise SwitchNotConnectedError(f"switch {switch.id} isn't connected")
 
+        event_name = "kytos/flow_manager.messages.out.ofpt_flow_mod"
         content = {"destination": switch.connection, "message": flow_mod}
 
         event = KytosEvent(name=event_name, content=content)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ add-ignore = D105
 
 [yala]
 radon mi args = --min C
-pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code --ignored-modules=napps.kytos.topology
+pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from --ignored-modules=napps.kytos.topology
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Fixes #26 

### Description of the change

- Raises `SwitchNotConnectedError` if the switch is not connected and return 424. 
- This PR [depends on this PR on kytos core](https://github.com/kytos-ng/kytos/pull/144), just so the `connection` is no longer `None`. 

Notice that as mentioned [on the dependent PR](https://github.com/kytos-ng/kytos/pull/144), there's still cases that we're not handling when the socket TX fails, `flow_manager` willl need to start listening to `kytos/core.openflow.connection.error`, but notice that this isn't also being propagated to via the rest request because that's sync, so for clients that need to handle that either they'll have to send an async `KytosEvent` for `kytos.flow_manager.flows.(install|delete)` when we have implemented full error handling, or they can rely on the `force` option that we'll have on issue #46, but that will likely take a lot longer on average - which might or not be a concern - so it'll depends on the responsiveness that the client needs. 

So, now if a switch isn't connected at the time when the flow mod is about to be sent, clients will get: 

```
{
    "code": 424,
    "description": "switch 00:00:00:00:00:00:00:01 isn't connected",
    "name": "Failed Dependency"
}
```