### PR TITLE
Updated requirements/dev.txt to run black via yala

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,6 @@
     # via
     #   -r requirements/dev.in
     #   kytos
-black>=21.10b0 # via -r requirements/dev.in
 astroid==2.8.4
     # via pylint
 backcall==0.1.0
@@ -22,14 +21,17 @@ backcall==0.1.0
     #   kytos
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-click>=7.1.2
+black>=21.10b0 # via -r requirements/dev.in
+click==8.0.3
     # via
+    #   black
     #   flask
     #   kytos
     #   pip-tools
-    #   black
 coverage==6.1.1
     # via kytos-flow-manager
+dataclasses==0.8
+    # via black
 decorator==4.4.2
     # via
     #   ipython
@@ -59,6 +61,7 @@ flask-socketio==4.2.1
 importlib-metadata==4.8.1
     # via
     #   backports.entry-points-selectable
+    #   click
     #   pep517
     #   pluggy
     #   tox
@@ -101,12 +104,16 @@ markupsafe==1.1.1
     #   kytos
 mccabe==0.6.1
     # via pylint
+mypy-extensions==0.4.3
+    # via black
 packaging==21.2
     # via tox
 parso==0.6.2
     # via
     #   jedi
     #   kytos
+pathspec==0.9.0
+    # via black
 pathtools==0.1.2
     # via
     #   kytos
@@ -125,6 +132,7 @@ pip-tools==6.4.0
     # via kytos-flow-manager
 platformdirs==2.4.0
     # via
+    #   black
     #   pylint
     #   virtualenv
 pluggy==1.0.0
@@ -161,6 +169,8 @@ python-socketio==4.5.1
     # via
     #   flask-socketio
     #   kytos
+regex==2021.11.2
+    # via black
 six==1.16.0
     # via
     #   flask-cors
@@ -175,7 +185,9 @@ toml==0.10.2
     #   pylint
     #   tox
 tomli==1.2.2
-    # via pep517
+    # via
+    #   black
+    #   pep517
 tox==3.24.4
     # via kytos-flow-manager
 traitlets==4.3.3
@@ -183,10 +195,13 @@ traitlets==4.3.3
     #   ipython
     #   kytos
 typed-ast==1.4.3
-    # via astroid
+    # via
+    #   astroid
+    #   black
 typing-extensions==3.10.0.2
     # via
     #   astroid
+    #   black
     #   importlib-metadata
     #   pylint
 virtualenv==20.10.0
@@ -205,7 +220,7 @@ wheel==0.37.0
     # via pip-tools
 wrapt==1.13.3
     # via astroid
-yala==3.0.1
+yala==3.1.0
     # via kytos-flow-manager
 zipp==3.6.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -146,12 +146,8 @@ class Linter(SimpleCommand):
 
     description = "lint Python source code"
 
-    # pylint: disable=fixme
     def run(self):
         """Run yala."""
-        # TODO submit a PR for yala to support black as a linter
-        print("black is running. It may take some seconds...")
-        check_call("git ls-files | grep -e '.py$' | xargs black --check", shell=True)
         print("Yala is running. It may take several seconds...")
         check_call("yala setup.py *.py serializers tests", shell=True)
 
@@ -289,7 +285,7 @@ setup(
         "dev": [
             "coverage",
             "pip-tools",
-            "yala",
+            "yala>=3.1.0",
             "tox",
         ],
     },


### PR DESCRIPTION
I'm bumping `yala` to version [`3.1.0`](https://github.com/cemsbr/yala/releases/tag/v3.1.0). Cadu has accepted and helped out to add `black` as a linter: 

```
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished black
INFO: Finished pylint
[isort] Skipped 5 files
:) No issues found.
``` 