### PR TITLE
[Feature] Added support for `force` option when sending flow mods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,14 @@ Removed
 Security
 ========
 
+[5.2.0] - 2021-11.17
+********************
+
+Added
+=====
+- Added support for ``force`` option when sending flow mods
+
+
 [5.1.0] - 2021-11.08
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -37,8 +37,8 @@ from .utils import _valid_consistency_ignored, cast_fields, new_flow_dict
 class FlowEntryState(Enum):
     """Enum for stored Flow Entry states."""
 
-    pending = "pending"  # initial state, it has been stored, but not confirmed yet
-    installed = "installed"  # final state, when the installtion has been confirmed
+    PENDING = "pending"  # initial state, it has been stored, but not confirmed yet
+    INSTALLED = "installed"  # final state, when the installtion has been confirmed
 
 
 class Main(KytosNApp):
@@ -214,7 +214,8 @@ class Main(KytosNApp):
                     try:
                         self._install_flows(command, flow, [switch], save=False)
                         log.info(
-                            f"Flow forwarded to switch {dpid} to be deleted. Flow: {flow}"
+                            "Flow forwarded to switch {dpid} to be deleted. "
+                            f"Flow: {flow}"
                         )
                         continue
                     except SwitchNotConnectedError:
@@ -230,7 +231,8 @@ class Main(KytosNApp):
                     try:
                         self._install_flows(command, flow, [switch], save=False)
                         log.info(
-                            f"Flow forwarded to switch {dpid} to be deleted. Flow: {flow}"
+                            "Flow forwarded to switch {dpid} to be deleted. "
+                            f"Flow: {flow}"
                         )
                         continue
                     except SwitchNotConnectedError:
@@ -301,7 +303,7 @@ class Main(KytosNApp):
 
     def _add_flow_store(self, flow_dict, switch):
         """Try to add a flow dict in the store idempotently."""
-        installed_flow = new_flow_dict(flow_dict, state=FlowEntryState.pending.value)
+        installed_flow = new_flow_dict(flow_dict, state=FlowEntryState.PENDING.value)
 
         stored_flows_box = deepcopy(self.stored_flows)
         cookie = int(flow_dict.get("cookie", 0))
@@ -516,7 +518,7 @@ class Main(KytosNApp):
                         raise
                 self._add_flow_mod_sent(flow_mod.header.xid, flow, command)
 
-                # TODO issue 2 and 7, only call _send_napp_event when get reply from switch
+                # TODO issue 2 and 7, only call this when get reply from switch
                 self._send_napp_event(switch, flow, command)
 
                 if not save:

--- a/main.py
+++ b/main.py
@@ -456,7 +456,7 @@ class Main(KytosNApp):
 
         force = bool(flows_dict.get("force", False))
         log.info(
-            f"Send FlowMod from request dpid: {dpid} command: {command}"
+            f"Send FlowMod from request dpid: {dpid} command: {command} force: {force}"
             f" flows_dict: {flows_dict}"
         )
         try:

--- a/main.py
+++ b/main.py
@@ -214,7 +214,7 @@ class Main(KytosNApp):
                     try:
                         self._install_flows(command, flow, [switch], save=False)
                         log.info(
-                            "Flow forwarded to switch {dpid} to be deleted. "
+                            f"Flow forwarded to switch {dpid} to be deleted. "
                             f"Flow: {flow}"
                         )
                         continue
@@ -231,7 +231,7 @@ class Main(KytosNApp):
                     try:
                         self._install_flows(command, flow, [switch], save=False)
                         log.info(
-                            "Flow forwarded to switch {dpid} to be deleted. "
+                            f"Flow forwarded to switch {dpid} to be deleted. "
                             f"Flow: {flow}"
                         )
                         continue
@@ -518,7 +518,7 @@ class Main(KytosNApp):
                         raise
                 self._add_flow_mod_sent(flow_mod.header.xid, flow, command)
 
-                # TODO issue 2 and 7, only call this when get reply from switch
+                # TODO issue 2, only call this when the reply is confirmed
                 self._send_napp_event(switch, flow, command)
 
                 if not save:

--- a/main.py
+++ b/main.py
@@ -31,14 +31,13 @@ from .settings import (
     ENABLE_CONSISTENCY_CHECK,
     FLOWS_DICT_MAX_SIZE,
 )
-from .utils import _valid_consistency_ignored, cast_fields
+from .utils import _valid_consistency_ignored, cast_fields, new_flow_dict
 
 
 class FlowEntryState(Enum):
     """Enum for stored Flow Entry states."""
 
     pending = "pending"  # initial state, it has been stored, but not confirmed yet
-    removed = "removed"  # final state, when the deletion has been confirmed
     installed = "installed"  # final state, when the installtion has been confirmed
 
 
@@ -278,9 +277,7 @@ class Main(KytosNApp):
 
     def _add_flow_store(self, flow_dict, switch):
         """Try to add a flow dict in the store idempotently."""
-        installed_flow = {}
-        installed_flow["flow"] = flow_dict
-        installed_flow["created_at"] = now().strftime("%Y-%m-%dT%H:%M:%S")
+        installed_flow = new_flow_dict(flow_dict, state=FlowEntryState.pending.value)
 
         stored_flows_box = deepcopy(self.stored_flows)
         cookie = int(flow_dict.get("cookie", 0))

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@
 import itertools
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
+from enum import Enum
 from threading import Lock
 
 from flask import jsonify, request
@@ -31,6 +32,14 @@ from .settings import (
     FLOWS_DICT_MAX_SIZE,
 )
 from .utils import _valid_consistency_ignored, cast_fields
+
+
+class FlowEntryState(Enum):
+    """Enum for stored Flow Entry states."""
+
+    pending = "pending"  # initial state, it has been stored, but not confirmed yet
+    removed = "removed"  # final state, when the deletion has been confirmed
+    installed = "installed"  # final state, when the installtion has been confirmed
 
 
 class Main(KytosNApp):

--- a/main.py
+++ b/main.py
@@ -403,7 +403,7 @@ class Main(KytosNApp):
                 "Error installing or deleting Flow through" f" Kytos Event: {error}"
             )
         except SwitchNotConnectedError:
-            # TODO handle event error
+            # TODO handle event error, issue 2
             pass
 
     @rest("v2/flows", methods=["POST"])

--- a/main.py
+++ b/main.py
@@ -482,7 +482,7 @@ class Main(KytosNApp):
                 try:
                     self._send_flow_mod(flow.switch, flow_mod)
                 except SwitchNotConnectedError:
-                    if not save or reraise_conn:
+                    if reraise_conn:
                         raise
                 self._add_flow_mod_sent(flow_mod.header.xid, flow, command)
 

--- a/main.py
+++ b/main.py
@@ -166,10 +166,16 @@ class Main(KytosNApp):
 
                 log.info(f"Consistency check: missing flow on switch {dpid}.")
                 flow = {"flows": [stored_flow["flow"]]}
-                self._install_flows("add", flow, [switch], save=False)
-                log.info(
-                    f"Flow forwarded to switch {dpid} to be installed. Flow: {flow}"
-                )
+                try:
+                    self._install_flows("add", flow, [switch], save=False)
+                    log.info(
+                        f"Flow forwarded to switch {dpid} to be installed. Flow: {flow}"
+                    )
+                except SwitchNotConnectedError:
+                    log.error(
+                        f"Failed to forward flow to switch {dpid} to be installed. "
+                        f"Flow: {flow}"
+                    )
 
     def check_storehouse_consistency(self, switch):
         """Check consistency of installed flows for a specific switch."""
@@ -200,20 +206,33 @@ class Main(KytosNApp):
                     )
                     flow = {"flows": [installed_flow.as_dict()]}
                     command = "delete_strict"
-                    self._install_flows(command, flow, [switch], save=False)
-                    log.info(
-                        f"Flow forwarded to switch {dpid} to be deleted. Flow: {flow}"
-                    )
-                    continue
+                    try:
+                        self._install_flows(command, flow, [switch], save=False)
+                        log.info(
+                            f"Flow forwarded to switch {dpid} to be deleted. Flow: {flow}"
+                        )
+                        continue
+                    except SwitchNotConnectedError:
+                        log.error(
+                            f"Failed to forward flow to switch {dpid} to be deleted. "
+                            f"Flow: {flow}"
+                        )
 
                 if installed_flow not in stored_flows_list:
                     log.info(f"Consistency check: alien flow on switch {dpid}")
                     flow = {"flows": [installed_flow.as_dict()]}
                     command = "delete_strict"
-                    self._install_flows(command, flow, [switch], save=False)
-                    log.info(
-                        f"Flow forwarded to switch {dpid} to be deleted. Flow: {flow}"
-                    )
+                    try:
+                        self._install_flows(command, flow, [switch], save=False)
+                        log.info(
+                            f"Flow forwarded to switch {dpid} to be deleted. Flow: {flow}"
+                        )
+                        continue
+                    except SwitchNotConnectedError:
+                        log.error(
+                            f"Failed to forward flow to switch {dpid} to be deleted. "
+                            f"Flow: {flow}"
+                        )
 
     # pylint: disable=attribute-defined-outside-init
     def _load_flows(self):

--- a/main.py
+++ b/main.py
@@ -456,8 +456,8 @@ class Main(KytosNApp):
 
         force = bool(flows_dict.get("force", False))
         log.info(
-            f"Send FlowMod from request dpid: {dpid} command: {command} force: {force}"
-            f" flows_dict: {flows_dict}"
+            f"Send FlowMod from request dpid: {dpid}, command: {command}, "
+            f"force: {force}, flows_dict: {flows_dict}"
         )
         try:
             if not dpid:

--- a/openapi.yml
+++ b/openapi.yml
@@ -38,12 +38,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                flows:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Flow'
+              $ref: '#/components/schemas/FlowsBody'
       responses:
         '202':
            description: FlowMod messages sent.
@@ -61,12 +56,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                flows:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Flow'
+              $ref: '#/components/schemas/FlowsBody'
       responses:
         '202':
           description: FlowMod messages sent.
@@ -103,12 +93,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                flows:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Flow'
+              $ref: '#/components/schemas/FlowsBody'
       parameters:
         - name: dpid
           in: path
@@ -133,12 +118,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                flows:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Flow'
+              $ref: '#/components/schemas/FlowsBody'
       parameters:
         - name: dpid
           in: path
@@ -301,3 +281,14 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Flow'
+    FlowsBody:
+      type: object
+      properties:
+        flows:
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow'
+        force:
+          type: boolean
+          description: The force option is for ignoring switch connection errors, and delegating the flows to be automatically sent later on via consistency check.
+          default: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ add-ignore = D105
 
 [yala]
 radon mi args = --min C
-pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from --ignored-modules=napps.kytos.topology
+pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments --ignored-modules=napps.kytos.topology
 
 [flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.1.0"
+NAPP_VERSION = "5.2.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -14,6 +14,7 @@ from kytos.lib.helpers import (
     get_test_client,
 )
 from napps.kytos.flow_manager.exceptions import SwitchNotConnectedError
+from napps.kytos.flow_manager.main import FlowEntryState
 
 
 # pylint: disable=protected-access, too-many-public-methods
@@ -473,6 +474,11 @@ class TestMain(TestCase):
         self.napp._add_flow_store(flow_dict, switch)
         assert len(self.napp.stored_flows[dpid]) == 1
         assert self.napp.stored_flows[dpid][0x20][0]["flow"]["actions"] == new_actions
+        assert (
+            self.napp.stored_flows[dpid][0x20][0]["state"]
+            == FlowEntryState.pending.value
+        )
+        assert self.napp.stored_flows[dpid][0x20][0]["created_at"]
 
     @patch("napps.kytos.flow_manager.storehouse.StoreHouse.save_flow")
     def test_add_overlapping_flow_diff_priority(self, *args):
@@ -514,6 +520,11 @@ class TestMain(TestCase):
 
         self.napp._add_flow_store(flow_dict, switch)
         assert len(self.napp.stored_flows[dpid][cookie]) == 2
+        assert (
+            self.napp.stored_flows[dpid][cookie][1]["state"]
+            == FlowEntryState.pending.value
+        )
+        assert self.napp.stored_flows[dpid][cookie][1]["created_at"]
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -283,7 +283,9 @@ class TestMain(TestCase):
             content={"dpid": dpid, "flow_dict": mock_flow_dict},
         )
         self.napp.event_flows_install_delete(event)
-        mock_install_flows.assert_called_with("add", mock_flow_dict, [switch])
+        mock_install_flows.assert_called_with(
+            "add", mock_flow_dict, [switch], reraise_conn=True
+        )
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_event_flows_install_delete(self, mock_install_flows):
@@ -297,7 +299,9 @@ class TestMain(TestCase):
             content={"dpid": dpid, "flow_dict": mock_flow_dict},
         )
         self.napp.event_flows_install_delete(event)
-        mock_install_flows.assert_called_with("delete", mock_flow_dict, [switch])
+        mock_install_flows.assert_called_with(
+            "delete", mock_flow_dict, [switch], reraise_conn=True
+        )
 
     def test_add_flow_mod_sent(self):
         """Test _add_flow_mod_sent method."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -184,10 +184,10 @@ class TestMain(TestCase):
     def test_rest_flow_mod_add_switch_not_connected_force(self, *args):
         """Test sending a flow mod when a swith isn't connected with force option."""
         (
-            mock_flow_factory,
+            _,
             mock_send_flow_mod,
-            mock_add_flow_mod_sent,
-            mock_send_napp_event,
+            _,
+            _,
             mock_store_changed_flows,
         ) = args
 
@@ -503,7 +503,7 @@ class TestMain(TestCase):
         assert self.napp.stored_flows[dpid][0x20][0]["flow"]["actions"] == new_actions
         assert (
             self.napp.stored_flows[dpid][0x20][0]["state"]
-            == FlowEntryState.pending.value
+            == FlowEntryState.PENDING.value
         )
         assert self.napp.stored_flows[dpid][0x20][0]["created_at"]
 
@@ -549,7 +549,7 @@ class TestMain(TestCase):
         assert len(self.napp.stored_flows[dpid][cookie]) == 2
         assert (
             self.napp.stored_flows[dpid][cookie][1]["state"]
-            == FlowEntryState.pending.value
+            == FlowEntryState.PENDING.value
         )
         assert self.napp.stored_flows[dpid][cookie][1]["created_at"]
 

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,18 @@
 """kytos/flow_manager utils."""
 
 from kytos.core import log
+from kytos.core.helpers import now
 
 from pyof.foundation.base import UBIntBase
+
+
+def new_flow_dict(flow_dict, state="pending"):
+    """Create a new flow dict to be stored."""
+    flow = {}
+    flow["flow"] = flow_dict
+    flow["created_at"] = now().strftime("%Y-%m-%dT%H:%M:%S")
+    flow["state"] = state
+    return flow
 
 
 def cast_fields(flow_dict):

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,9 @@
 """kytos/flow_manager utils."""
 
+from pyof.foundation.base import UBIntBase
+
 from kytos.core import log
 from kytos.core.helpers import now
-
-from pyof.foundation.base import UBIntBase
 
 
 def new_flow_dict(flow_dict, state="pending"):

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,8 @@
 """kytos/flow_manager utils."""
 
 from kytos.core import log
-from kytos.core.helpers import now
 
 from pyof.foundation.base import UBIntBase
-
-
-def new_archive_flow(dict_flow, reason):
-    """Build an archive flow given an stored dict flow."""
-    archive_flow = dict(dict_flow)
-    archive_flow["deleted_at"] = now().strftime("%Y-%m-%dT%H:%M:%S")
-    archive_flow["reason"] = reason
-    return archive_flow
 
 
 def cast_fields(flow_dict):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,66 @@
+"""kytos/flow_manager utils."""
+
+from kytos.core import log
+from kytos.core.helpers import now
+
+from pyof.foundation.base import UBIntBase
+
+
+def new_archive_flow(dict_flow, reason):
+    """Build an archive flow given an stored dict flow."""
+    archive_flow = dict(dict_flow)
+    archive_flow["deleted_at"] = now().strftime("%Y-%m-%dT%H:%M:%S")
+    archive_flow["reason"] = reason
+    return archive_flow
+
+
+def cast_fields(flow_dict):
+    """Make casting the match fields from UBInt() to native int ."""
+    match = flow_dict["match"]
+    for field, value in match.items():
+        if isinstance(value, UBIntBase):
+            match[field] = int(value)
+    flow_dict["match"] = match
+    return flow_dict
+
+
+def _validate_range(values):
+    """Check that the range of flows ignored by the consistency is valid."""
+    if len(values) != 2:
+        msg = f"The tuple must have 2 items, not {len(values)}"
+        raise ValueError(msg)
+    first, second = values
+    if second < first:
+        msg = f"The first value is bigger than the second: {values}"
+        raise ValueError(msg)
+    if not isinstance(first, int) or not isinstance(second, int):
+        msg = f"Expected a tuple of integers, received {values}"
+        raise TypeError(msg)
+
+
+def _valid_consistency_ignored(consistency_ignored_list):
+    """Check the format of the list of ignored consistency flows.
+
+    Check that the list of ignored flows in the consistency check
+    is well formatted. Returns True, if the list is well
+    formatted, otherwise return False.
+    """
+    msg = (
+        "The list of ignored flows in the consistency check"
+        "is not well formatted, it will be ignored: %s"
+    )
+    for consistency_ignored in consistency_ignored_list:
+        if isinstance(consistency_ignored, tuple):
+            try:
+                _validate_range(consistency_ignored)
+            except (TypeError, ValueError) as error:
+                log.warn(msg, error)
+                return False
+        elif not isinstance(consistency_ignored, (int, tuple)):
+            error_msg = (
+                "The elements must be of class int or tuple"
+                f" but they are: {type(consistency_ignored)}"
+            )
+            log.warn(msg, error_msg)
+            return False
+    return True


### PR DESCRIPTION
Fixes #46 

### Description of the change

- Added support for ``force`` option when sending flow mods

![2021-11-17-152552_930x697_scrot](https://user-images.githubusercontent.com/1010796/142266658-283cdf7d-3c4d-4e73-b359-0d60f1cf87dd.png)


Once this change lands, clients can decide reliably if they want to ``force`` the flow mode to be sent later on (via consistency check) in case any switch connection errors happened as the flows were being installed. So, it's up to each client to decide if the client wants the flows to be either forced or not, for example, if `mef_eline` wants the flows being installed or fail immediately in case a switch isn't connected, then set `force: false`, for applications that don't care when the flow should be installed, and there's no other potential paths that the client could make of use then setting `force: true` would be handy. 

Notice that errors could still happen even when `force: true` is set (for instance, imagine a client sends a flow mod with force true, the switch isn't available and then the installation has an unsupported instruction for that switch), the rest of error propagation, and more tests for this, will be covered on issue #2.  

