### PR TITLE
[Feature] Generate flow events for every flow added or removed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,23 @@ Removed
 Security
 ========
 
+[5.3.0] - 2021-11.21
+********************
+
+Added
+=====
+- Started listening to ``kytos/core.openflow.connection.error`` and propagating the error
+- Added listen_to for ofpt_flow_removed
+- Publish the event ``kytos/flow_manager.flow.removed`` on OFPT_FLOW_REMOVED
+- Parametrized and added ``_id`` on stored flows to confirm flow operations
+- Parametrized the flow on ``SwitchNotConnectedError`` exception
+- Added support to update flow ``state`` and flows are confirmed by the consistency check
+
+Changed
+=======
+
+- Publish the event ``kytos/flow_manager.flow.added`` only when the flow is confirmed
+
 [5.2.0] - 2021-11.17
 ********************
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -9,6 +9,7 @@ class SwitchNotConnectedError(Exception):
     """Exception raised when a switch's connection isn't connected."""
 
     def __init__(self, message, flow=None):
+        """Init of SwitchNotConnectedError."""
         self.message = message
         self.flow = flow
         super().__init__(message)

--- a/exceptions.py
+++ b/exceptions.py
@@ -7,3 +7,8 @@ class InvalidCommandError(Exception):
 
 class SwitchNotConnectedError(Exception):
     """Exception raised when a switch's connection isn't connected."""
+
+    def __init__(self, message, flow=None):
+        self.message = message
+        self.flow = flow
+        super().__init__(message)

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -91,6 +91,8 @@ class Main(KytosNApp):
     def stored_flows_by_state(self, dpid, state):
         """Get stored flows dict filter by a state."""
         filtered_flows = {}
+        if dpid not in self.stored_flows:
+            return filtered_flows
         for entry in self.stored_flows_list(dpid):
             if entry.get("state") == state:
                 filtered_flows[entry["_id"]] = entry

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ class Main(KytosNApp):
         return itertools.chain(*list(self.stored_flows[dpid].values()))
 
     def stored_flows_by_state(self, dpid, state):
-        """Stored flows dict filter by a state."""
+        """Get stored flows dict filter by a state."""
         filtered_flows = {}
         for entry in self.stored_flows_list(dpid):
             if entry.get("state") and entry["state"] == state:
@@ -164,7 +164,7 @@ class Main(KytosNApp):
         installed_flows = self.switch_flows_by_id(switch)
 
         flow_ids_to_update = set()
-        for _id, pending_flow in pending_flows.items():
+        for _id in pending_flows:
             if _id not in installed_flows:
                 continue
 
@@ -306,7 +306,7 @@ class Main(KytosNApp):
         else:
             log.info("Flows loaded.")
 
-    def _del_matched_flows_store(self, flow_dict, flow_id, switch):
+    def _del_matched_flows_store(self, flow_dict, _flow_id, switch):
         """Try to delete matching stored flows given a flow dict."""
         stored_flows_box = deepcopy(self.stored_flows)
 
@@ -636,6 +636,7 @@ class Main(KytosNApp):
 
     @listen_to("kytos/core.openflow.connection.error")
     def on_openflow_connection_error(self, event):
+        """Listen to openflow connection error and publish the flow error."""
         switch = event.content["destination"].switch
         flow = event.message
         self._send_napp_event(switch, flow, "error")

--- a/main.py
+++ b/main.py
@@ -141,6 +141,13 @@ class Main(KytosNApp):
         """Check the consistency of a switch upon receiving flow stats."""
         self.check_consistency(event.content["switch"])
 
+    @listen_to("kytos/of_core.v0x0[14].messages.in.ofpt_flow_removed")
+    def on_ofpt_flow_removed(self, event):
+        """Listen to OFPT_FLOW_REMOVED and publish to subscribers."""
+        switch = event.source.switch
+        flow = event.message
+        self._send_napp_event(switch, flow, "delete")
+
     @listen_to("kytos/of_core.flow_stats.received")
     def on_flow_stats_publish_installed_flows(self, event):
         """Listen to flow stats to publish installed flows when they're confirmed."""

--- a/main.py
+++ b/main.py
@@ -200,10 +200,7 @@ class Main(KytosNApp):
     @staticmethod
     def switch_flows_by_id(switch):
         """Build switch.flows indexed by id."""
-        installed_flows = {}
-        for flow in switch.flows:
-            installed_flows[flow.id] = flow
-        return installed_flows
+        return {flow.id: flow for flow in switch.flows}
 
     def check_switch_consistency(self, switch):
         """Check consistency of stored flows for a specific switch."""

--- a/main.py
+++ b/main.py
@@ -472,9 +472,8 @@ class Main(KytosNApp):
             log.error(
                 "Error installing or deleting Flow through" f" Kytos Event: {error}"
             )
-        except SwitchNotConnectedError:
-            # TODO handle event error, issue 2
-            pass
+        except SwitchNotConnectedError as error:
+            self._send_napp_event(switch, error.flow, "error")
 
     @rest("v2/flows", methods=["POST"])
     @rest("v2/flows/<dpid>", methods=["POST"])
@@ -600,7 +599,9 @@ class Main(KytosNApp):
 
     def _send_flow_mod(self, switch, flow_mod):
         if not switch.is_connected():
-            raise SwitchNotConnectedError(f"switch {switch.id} isn't connected")
+            raise SwitchNotConnectedError(
+                f"switch {switch.id} isn't connected", flow_mod
+            )
 
         event_name = "kytos/flow_manager.messages.out.ofpt_flow_mod"
         content = {"destination": switch.connection, "message": flow_mod}

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ class Main(KytosNApp):
         """Get stored flows dict filter by a state."""
         filtered_flows = {}
         for entry in self.stored_flows_list(dpid):
-            if entry.get("state") and entry["state"] == state:
+            if entry.get("state") == state:
                 filtered_flows[entry["_id"]] = entry
         return filtered_flows
 

--- a/main.py
+++ b/main.py
@@ -449,7 +449,6 @@ class Main(KytosNApp):
 
         return jsonify(switch_flows)
 
-    # pylint: disable=fixme
     @listen_to("kytos.flow_manager.flows.(install|delete)")
     def event_flows_install_delete(self, event):
         """Install or delete flows in the switches through events.
@@ -558,7 +557,6 @@ class Main(KytosNApp):
         except SwitchNotConnectedError as error:
             raise FailedDependency(str(error))
 
-    # pylint: disable=fixme
     def _install_flows(
         self, command, flows_dict, switches=[], save=True, reraise_conn=True
     ):

--- a/main.py
+++ b/main.py
@@ -626,6 +626,12 @@ class Main(KytosNApp):
         event_app = KytosEvent(name, content)
         self.controller.buffers.app.put(event_app)
 
+    @listen_to("kytos/core.openflow.connection.error")
+    def on_openflow_connection_error(self, event):
+        switch = event.content["destination"].switch
+        flow = event.message
+        self._send_napp_event(switch, flow, "error")
+
     @listen_to(".*.of_core.*.ofpt_error")
     def handle_errors(self, event):
         """Receive OpenFlow error and send a event.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ add-ignore = D105
 
 [yala]
 radon mi args = --min C
-pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments --ignored-modules=napps.kytos.topology
+pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments,too-many-public-methods --ignored-modules=napps.kytos.topology
 
 [flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.2.0"
+NAPP_VERSION = "5.3.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -171,7 +171,9 @@ class TestMain(TestCase):
     def test_rest_flow_mod_add_switch_not_connected(self, mock_install_flows):
         """Test sending a flow mod when a swith isn't connected."""
         api = get_test_client(self.napp.controller, self.napp)
-        mock_install_flows.side_effect = SwitchNotConnectedError
+        mock_install_flows.side_effect = SwitchNotConnectedError(
+            "error", flow=MagicMock()
+        )
 
         url = f"{self.API_URL}/v2/flows"
         response = api.post(url, json={"flows": [{"priority": 25}]})
@@ -194,7 +196,9 @@ class TestMain(TestCase):
         ) = args
 
         api = get_test_client(self.napp.controller, self.napp)
-        mock_send_flow_mod.side_effect = SwitchNotConnectedError
+        mock_send_flow_mod.side_effect = SwitchNotConnectedError(
+            "error", flow=MagicMock()
+        )
 
         _id = str(uuid4())
         serializer = MagicMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -582,7 +582,8 @@ class TestMain(TestCase):
             "actions": new_actions,
         }
 
-        self.napp._add_flow_store(overlapping_flow, switch)
+        _id = str(uuid4())
+        self.napp._add_flow_store(overlapping_flow, _id, switch)
         assert len(self.napp.stored_flows[dpid][cookie]) == len(stored_flows_list)
 
         # only the last flow is expected to be strictly matched

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -250,7 +250,7 @@ class TestMain(TestCase):
 
         mock_send_flow_mod.assert_called_with(flow.switch, flow_mod)
         mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid, flow, "add")
-        mock_send_napp_event.assert_called_with(self.switch_01, flow, "add")
+        mock_send_napp_event.assert_called_with(self.switch_01, flow, "pending")
 
     @patch("napps.kytos.flow_manager.main.Main._store_changed_flows")
     @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
@@ -282,7 +282,7 @@ class TestMain(TestCase):
         mock_add_flow_mod_sent.assert_called_with(
             flow_mod.header.xid, flow, "delete_strict"
         )
-        mock_send_napp_event.assert_called_with(self.switch_01, flow, "delete_strict")
+        mock_send_napp_event.assert_called_with(self.switch_01, flow, "pending")
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_event_add_flow(self, mock_install_flows):

--- a/utils.py
+++ b/utils.py
@@ -6,9 +6,10 @@ from kytos.core import log
 from kytos.core.helpers import now
 
 
-def new_flow_dict(flow_dict, state="pending"):
+def new_flow_dict(flow_dict, _id=None, state="pending"):
     """Create a new flow dict to be stored."""
     flow = {}
+    flow["_id"] = _id
     flow["flow"] = flow_dict
     flow["created_at"] = now().strftime("%Y-%m-%dT%H:%M:%S")
     flow["state"] = state


### PR DESCRIPTION
Fixes #2  

### Description of the change

This PR added support to publish the rest of flows events to support reliably publishing events when flows are added, removed, still pending (not confirmed yet), and also handled switch connection error `kytos/core.openflow.connection.error` to bubble up the error to the caller. So, now `flow_manager` clients will be able to react accordingly and handle each event as needed based on their use case, not necessarily all clients will have to react and handle, but as they need, the events to completely handle every case are available, [handling the `kytos/flow_manager.flow.error` event is highly encouraged though at least, as `mef_eline` already does](https://github.com/kytos-ng/mef_eline/blob/master/main.py#L664-665).

### Release notes

`version [5.3.0] - 2021-11.21`

#### Added

- Started listening to ``kytos/core.openflow.connection.error`` and propagating the error
- Added listen_to for ofpt_flow_removed
- Publish the event ``kytos/flow_manager.flow.removed`` on `OFPT_FLOW_REMOVED`
- Parametrized and added ``_id`` on stored flows to confirm flow operations
- Parametrized the flow on ``SwitchNotConnectedError`` exception
- Added support to update flow ``state`` and flows are confirmed by the consistency check

#### Changed

- Publish the event ``kytos/flow_manager.flow.added`` only when the flow is confirmed

