### PR TITLE
[Feature] consistency_check concurrency execution control 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,14 @@ Removed
 Security
 ========
 
+[5.4.0] - 2021-11.23
+********************
+
+Added
+=====
+- Added thread concurrency control per switch when executing check_consistency
+
+
 [5.3.0] - 2021-11.21
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import itertools
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from enum import Enum
-from queue import Queue
 from threading import Lock
 
 from flask import jsonify, request
@@ -66,7 +65,7 @@ class Main(KytosNApp):
 
         self._storehouse_lock = Lock()
         self._flow_mods_sent_lock = Lock()
-        self._check_consistency_queues = defaultdict(Queue)
+        self._check_consistency_exec_at = {}
         self._check_consistency_locks = defaultdict(Lock)
 
         # Format of stored flow data:
@@ -186,17 +185,25 @@ class Main(KytosNApp):
         if not ENABLE_CONSISTENCY_CHECK or not switch.is_enabled():
             return
         with self._check_consistency_locks[switch.id]:
-            if not self._check_consistency_queues[switch.id].empty():
-                log.debug(f"skipping concurrent check_consistency exec on {switch.id}")
+            exec_at = self._check_consistency_exec_at.get(
+                switch.id, "0001-01-01T00:00:00"
+            )
+            exec_time_diff = (now() - get_time(exec_at)).seconds
+            if exec_time_diff <= STATS_INTERVAL / 2:
+                log.info(
+                    f"Skipping recent consistency check exec on switch {switch.id}, "
+                    f"last checked at {exec_at}, diff in secs: {exec_time_diff}"
+                )
                 return
 
-            self._check_consistency_queues[switch.id].put(1)
-            log.debug(f"check_consistency on switch {switch.id} has started")
-            self.check_storehouse_consistency(switch)
-            if switch.dpid in self.stored_flows:
-                self.check_switch_consistency(switch)
-            log.debug(f"check_consistency on switch {switch.id} is done")
-            self._check_consistency_queues[switch.id].get()
+            self._check_consistency_exec_at[switch.id] = now().strftime(
+                "%Y-%m-%dT%H:%M:%S"
+            )
+        log.debug(f"check_consistency on switch {switch.id} has started")
+        self.check_storehouse_consistency(switch)
+        if switch.dpid in self.stored_flows:
+            self.check_switch_consistency(switch)
+        log.debug(f"check_consistency on switch {switch.id} is done")
 
     @staticmethod
     def switch_flows_by_cookie(switch):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.3.0"
+NAPP_VERSION = "5.4.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,5 @@
 """Test Main methods."""
+import threading
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -1156,3 +1157,33 @@ class TestMain(TestCase):
             self.napp.stored_flows = {dpid: {0: [flow]}}
             self.napp.check_storehouse_consistency(switch)
             self.assertEqual(mock_install_flows.call_count, called)
+
+    def test_check_consistency_concurrency_control(self):
+        """Test check consistency concurrency control, only a single
+        thread per switch is expected within a delta T."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        switch.id = dpid
+        n_threads = 10
+
+        check_store = MagicMock()
+        check_switch = MagicMock()
+        self.napp.check_storehouse_consistency = check_store
+        self.napp.check_switch_consistency = check_switch
+
+        # upfront a call
+        self.napp.check_consistency(switch)
+
+        threads = []
+        for _ in range(n_threads):
+            thread = threading.Thread(
+                target=self.napp.check_consistency, args=(switch,)
+            )
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # only a single call to check_storehouse_consistency is expected
+        assert check_store.call_count == 1


### PR DESCRIPTION
Fixes #32

### Description of the change

- Added thread concurrency control execution per switch when executing `check_consistency`. I ended up using the `STATS_INTERVAL / 2` as a reference to skip executions per switch, without using this a reference it could still end up with cases where it would still execute relatively close to previous executions, so this enforces some back pressure. 
