### PR TITLE
[Feature] Added support for barrier request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,17 @@ Removed
 Security
 ========
 
+[5.5.0] - 2021-11.24
+********************
+
+Added
+=====
+- Added support for ofpt_barrier_request and ofpt_barrier_reply
+- Mapped barrier reply xid with flow mod xid to correlate them, and to also to confirm installed flows in an event-driver manner.
+- Stored in memory errors of flow mod xids to correlate them when a barrier reply is received.
+- Added thread locks accordingly for the dictionaries used.
+- Added support to delete the stored_flow once an ofpt_error when receiving a barrier reply, to avoid this flow to keep being sent via consistency check.
+
 [5.4.0] - 2021-11.23
 ********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,14 @@ Removed
 Security
 ========
 
+[5.4.0] - 2021-11.23
+********************
+
+Added
+=====
+- Added thread concurrency control per switch when executing check_consistency
+
+
 [5.3.0] - 2021-11.21
 ********************
 

--- a/barrier_request.py
+++ b/barrier_request.py
@@ -1,3 +1,4 @@
+"""kytos/flow_manager barrier_request."""
 from pyof.v0x01.controller2switch.barrier_request import BarrierRequest as BReq10
 from pyof.v0x04.controller2switch.barrier_request import BarrierRequest as BReq13
 

--- a/barrier_request.py
+++ b/barrier_request.py
@@ -1,0 +1,8 @@
+from pyof.v0x01.controller2switch.barrier_request import BarrierRequest as BReq10
+from pyof.v0x04.controller2switch.barrier_request import BarrierRequest as BReq13
+
+
+def new_barrier_request(version, **kwargs):
+    """Instantiate a barrier request given an OF version."""
+    barrier_requests = {0x01: BReq10(**kwargs), 0x04: BReq13(**kwargs)}
+    return barrier_requests[version]

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -784,12 +784,16 @@ class Main(KytosNApp):
         )
 
     @listen_to(".*.of_core.*.ofpt_error")
-    def handle_errors(self, event):
+    def on_handle_errors(self, event):
         """Receive OpenFlow error and send a event.
 
         The event is sent only if the error is related to a request made
         by flow_manager.
         """
+        self.handle_errors(event)
+
+    def handle_errors(self, event):
+        """handle OpenFlow error."""
         message = event.content["message"]
 
         connection = event.source

--- a/main.py
+++ b/main.py
@@ -201,13 +201,6 @@ class Main(KytosNApp):
             error_kwargs = self._flow_mods_sent_error.get(flow_xid)
         if not error_kwargs:
             self._publish_installed_flow(switch, flow)
-            return
-
-        log.warning(
-            f"Deleting flow: {flow.as_dict()}, xid: {flow_xid}, cookie: {flow.cookie}, "
-            f"error: {error_kwargs}"
-        )
-        self._del_stored_flow_by_id(switch.id, flow.cookie, flow.id)
 
     def _publish_installed_flow(self, switch, flow):
         """Publish installed flow when it's confirmed."""
@@ -839,4 +832,9 @@ class Main(KytosNApp):
             }
             with self._flow_mods_sent_error_locks[switch.id]:
                 self._flow_mods_sent_error[int(event.message.header.xid)] = error_kwargs
+            log.warning(
+                f"Deleting flow: {flow.as_dict()}, xid: {xid}, cookie: {flow.cookie}, "
+                f"error: {error_kwargs}"
+            )
+            self._del_stored_flow_by_id(switch.id, flow.cookie, flow.id)
             self._send_napp_event(flow.switch, flow, "error", **error_kwargs)

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from werkzeug.exceptions import (
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import get_time, listen_to, now
 
+from .barrier_request import new_barrier_request
 from .exceptions import InvalidCommandError, SwitchNotConnectedError
 from .settings import (
     CONSISTENCY_COOKIE_IGNORED_RANGE,
@@ -33,7 +34,6 @@ from .settings import (
     FLOWS_DICT_MAX_SIZE,
 )
 from .utils import _valid_consistency_ignored, cast_fields, new_flow_dict
-from .barrier_request import new_barrier_request
 
 
 class FlowEntryState(Enum):
@@ -204,7 +204,6 @@ class Main(KytosNApp):
 
     def _publish_installed_flow(self, switch, flow):
         """Publish installed flow when it's confirmed."""
-
         self._send_napp_event(switch, flow, "add")
         with self._storehouse_lock:
             self._update_flow_state_store(
@@ -214,7 +213,6 @@ class Main(KytosNApp):
     @listen_to("kytos/of_core.flow_stats.received")
     def on_flow_stats_publish_installed_flows(self, event):
         """Listen to flow stats to publish installed flows when they're confirmed."""
-
         self.publish_installed_flows(event.content["switch"])
 
     def publish_installed_flows(self, switch):

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from flask import jsonify, request
 from napps.kytos.flow_manager.match import match_flow
 from napps.kytos.flow_manager.storehouse import StoreHouse
 from napps.kytos.of_core.flow import FlowFactory
-from napps.kytos.of_core.settings import STATS_INTERVAL, ENABLE_BARRIER_REQUEST
+from napps.kytos.of_core.settings import STATS_INTERVAL
 from pyof.v0x01.asynchronous.error_msg import BadActionCode
 from pyof.v0x01.common.phy_port import PortConfig
 from werkzeug.exceptions import (
@@ -28,6 +28,7 @@ from .exceptions import InvalidCommandError, SwitchNotConnectedError
 from .settings import (
     CONSISTENCY_COOKIE_IGNORED_RANGE,
     CONSISTENCY_TABLE_ID_IGNORED_RANGE,
+    ENABLE_BARRIER_REQUEST,
     ENABLE_CONSISTENCY_CHECK,
     FLOWS_DICT_MAX_SIZE,
 )

--- a/settings.py
+++ b/settings.py
@@ -5,6 +5,7 @@ FLOWS_DICT_MAX_SIZE = 10000
 # Time (in seconds) to wait retrieve box from storehouse
 BOX_RESTORE_TIMER = 0.1
 ENABLE_CONSISTENCY_CHECK = True
+ENABLE_BARRIER_REQUEST = True
 
 # List of flows ignored by the consistency check
 # To filter by a cookie or `table_id` use [value]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.4.0"
+NAPP_VERSION = "5.5.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.3.0"
+NAPP_VERSION = "5.4.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -376,11 +376,13 @@ class TestMain(TestCase):
     def test_handle_errors(self, mock_send_napp_event, mock_del_stored):
         """Test handle_errors method."""
         flow = MagicMock()
+        flow.as_dict.return_value = {}
+        flow.cookie = 0
         self.napp._flow_mods_sent[0] = (flow, "add")
 
         switch = get_switch_mock("00:00:00:00:00:00:00:01")
         switch.connection = get_connection_mock(
-            0x04, get_switch_mock("00:00:00:00:00:00:00:02")
+            0x04, get_switch_mock("00:00:00:00:00:00:00:01")
         )
 
         protocol = MagicMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -371,8 +371,9 @@ class TestMain(TestCase):
 
         self.assertEqual(mock_buffers_put.call_count, 4)
 
+    @patch("napps.kytos.flow_manager.main.Main._del_stored_flow_by_id")
     @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
-    def test_handle_errors(self, mock_send_napp_event):
+    def test_handle_errors(self, mock_send_napp_event, mock_del_stored):
         """Test handle_errors method."""
         flow = MagicMock()
         self.napp._flow_mods_sent[0] = (flow, "add")
@@ -405,6 +406,7 @@ class TestMain(TestCase):
             error_code=5,
             error_type=2,
         )
+        mock_del_stored.assert_called()
 
     @patch("napps.kytos.flow_manager.main.StoreHouse.get_data")
     def test_load_flows(self, mock_storehouse):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -184,6 +184,7 @@ class TestMain(TestCase):
     @patch("napps.kytos.flow_manager.main.Main._store_changed_flows")
     @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
     @patch("napps.kytos.flow_manager.main.Main._add_flow_mod_sent")
+    @patch("napps.kytos.flow_manager.main.Main._send_barrier_request")
     @patch("napps.kytos.flow_manager.main.Main._send_flow_mod")
     @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_rest_flow_mod_add_switch_not_connected_force(self, *args):
@@ -191,6 +192,7 @@ class TestMain(TestCase):
         (
             mock_flow_factory,
             mock_send_flow_mod,
+            _,
             _,
             _,
             mock_store_changed_flows,
@@ -230,6 +232,7 @@ class TestMain(TestCase):
     @patch("napps.kytos.flow_manager.main.Main._store_changed_flows")
     @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
     @patch("napps.kytos.flow_manager.main.Main._add_flow_mod_sent")
+    @patch("napps.kytos.flow_manager.main.Main._send_barrier_request")
     @patch("napps.kytos.flow_manager.main.Main._send_flow_mod")
     @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_install_flows(self, *args):
@@ -237,6 +240,7 @@ class TestMain(TestCase):
         (
             mock_flow_factory,
             mock_send_flow_mod,
+            mock_send_barrier_request,
             mock_add_flow_mod_sent,
             mock_send_napp_event,
             _,
@@ -256,10 +260,12 @@ class TestMain(TestCase):
         mock_send_flow_mod.assert_called_with(flow.switch, flow_mod)
         mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid, flow, "add")
         mock_send_napp_event.assert_called_with(self.switch_01, flow, "pending")
+        mock_send_barrier_request.assert_called()
 
     @patch("napps.kytos.flow_manager.main.Main._store_changed_flows")
     @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
     @patch("napps.kytos.flow_manager.main.Main._add_flow_mod_sent")
+    @patch("napps.kytos.flow_manager.main.Main._send_barrier_request")
     @patch("napps.kytos.flow_manager.main.Main._send_flow_mod")
     @patch("napps.kytos.flow_manager.main.FlowFactory.get_class")
     def test_install_flows_with_delete_strict(self, *args):
@@ -267,6 +273,7 @@ class TestMain(TestCase):
         (
             mock_flow_factory,
             mock_send_flow_mod,
+            mock_send_barrier_request,
             mock_add_flow_mod_sent,
             mock_send_napp_event,
             _,
@@ -288,6 +295,7 @@ class TestMain(TestCase):
             flow_mod.header.xid, flow, "delete_strict"
         )
         mock_send_napp_event.assert_called_with(self.switch_01, flow, "pending")
+        mock_send_barrier_request.assert_called()
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_event_add_flow(self, mock_install_flows):


### PR DESCRIPTION
Fixes #7

### Description of the change

Added support for barrier request

### Release notes

`version [5.5.0] - 2021-11.24`

- Added support for ofpt_barrier_request and ofpt_barrier_reply
- Mapped barrier reply xid with flow mod xid to correlate them, and to also to confirm installed flows in an event-driver manner.
- Stored in memory errors of flow mod xids to correlate them when a barrier reply is received.
- Added thread locks accordingly for the dictionaries used.
- Added support to delete the stored_flow once an ofpt_error when receiving a barrier reply, to avoid this flow to keep being sent via consistency check.

### Additional information 

With barrier request and reply, now we can confirm more promptly (event-driven) a flow mod xid without exclusively depending on the consistency check routine:

1) Example when an ofpt_error happens (once clients implement `kytos/flow_manager.flow.error`) like `mef_eline` does, notice that locally running this on mininet it took only a few milliseconds to report back to the client: 

```
kytos $> 2021-11-24 19:17:03,873 - INFO [kytos.napps.kytos/flow_manager] (Thread-536) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: True, flows_dict: {'
force': True, 'flows': [{'priority': 100, 'match': {'in_port': 10000, 'dl_vlan': 10000}, 'actions': [{'action_type': 'output', 'port': 2}]}]}
2021-11-24 19:17:03,886 - INFO [kytos.napps.kytos/flow_manager] (Thread-537) Flow saved in kytos.flow.persistence.286a9c96a07344579e706f2a9664dd28
2021-11-24 19:17:03,887 - WARNING [kytos.napps.kytos/flow_manager] (Thread-539) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 10000, 'dl_vlan
': 10000}, 'priority': 100, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 0, 'id': '1de03578ac15ca64cd96ca6639652e97', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_t
ype': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}, xid: 1704388584, cookie: 0, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_MATC
H: 4>), 'error_code': <BadMatchCode.OFPBMC_BAD_VALUE: 7>}
2021-11-24 19:17:03,890 - INFO [kytos.napps.kytos/mef_eline] (Thread-542) caught error {'datapath': Switch('00:00:00:00:00:00:00:01'), 'flow': <napps.kytos.of_core.v0x04.flow.Flow object
at 0x7fc4d427ff60>, 'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_MATCH: 4>), 'error_code': <BadMatchCode.OFPBMC_BAD_VALUE: 7>}
2021-11-24 19:17:03,890 - INFO [kytos.napps.kytos/flow_manager] (Thread-541) Flow saved in kytos.flow.persistence.286a9c96a07344579e706f2a9664dd28
```

2) Example of a flow xid confirmation for clients that listen to `kytos/flow_manager.flow.added`, notice that it also only took a few milliseconds (it's running locally on mininet though): 

```
kytos $> 2021-11-24 19:17:32,267 - INFO [kytos.napps.kytos/flow_manager] (Thread-687) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: True, flows_dict: {'
force': True, 'flows': [{'priority': 100, 'match': {'in_port': 1, 'dl_vlan': 301}, 'actions': [{'action_type': 'output', 'port': 2}]}]}
2021-11-24 19:17:32,278 - INFO [kytos.napps.kytos/flow_manager] (Thread-688) Flow saved in kytos.flow.persistence.286a9c96a07344579e706f2a9664dd28
2021-11-24 19:17:32,280 - INFO [kytos.napps.kytos/mef_eline] (Thread-691) caught added {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vlan': 301}, 'priority': 100, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 0, 'id': 'a2e59640d3d6f9049cc0648eeb7543e4', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}
2021-11-24 19:17:32,285 - INFO [kytos.napps.kytos/flow_manager] (Thread-692) Flow saved in kytos.flow.persistence.286a9c96a07344579e706f2a9664dd28
```

I've also run a stress test requests 500 flow mod delete followed by add, trying to potentially mess up the order of the flows being processed like @italovalcy presented this idea to me the other day, with a similar script it installed correctly 500+1 flows: 

```
#!/usr/bin/env python
# -*- coding: utf-8 -*-
import requests


def request_delete_add_flows(vlans, dpid="00:00:00:00:00:00:00:01") -> None:
    for vlan in vlans:
        payload = {
            "flows": [
                {
                    "priority": 100,
                    "match": {"in_port": 1, "dl_vlan": vlan},
                    "actions": [{"action_type": "output", "port": 2}],
                }
            ],
        }
        r = requests.delete(
            f"http://localhost:8181/api/kytos/flow_manager/v2/flows/{dpid}",
            json=payload,
        )
        assert r.status_code == 202, r.text
        r = requests.post(
            f"http://localhost:8181/api/kytos/flow_manager/v2/flows/{dpid}",
            json=payload,
        )
        assert r.status_code == 202, r.text


def main() -> None:
    """Main function."""
    n_vlans = 500
    request_delete_add_flows(range(n_vlans))


if __name__ == "__main__":
    main()
```

```
❯ curl http://127.0.0.1:8181/api/kytos/storehouse/v1/kytos.flow.persistence/286a9c96a07344579e706f2a9664dd28 | jq '.["flow_persistence"]["00:00:00:00:00:00:00:01"]["0"]' | jq length
501
```

  