### PR TITLE
[Feature] Added an upper rotating limit for barrier replies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,17 @@ Removed
 Security
 ========
 
+[5.6.0] - 2021-12.17
+********************
+
+Added
+=====
+- Added an upper bound rotating limit for the number of barrier replies
+
+Changed
+=======
+- Changed ``_flow_mods_sent_error_locks`` and ``_pending_barrier_locks`` to be safer
+
 [5.5.0] - 2021-11.24
 ********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Added
 
 Changed
 =======
-- Changed ``_flow_mods_sent_error_locks`` and ``_pending_barrier_locks`` to be safer
+- Changed ``_flow_mods_sent_error_locks``, ``_pending_barrier_locks``, and ``_check_consistency_locks`` to be safer
 
 [5.5.0] - 2021-11.24
 ********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ class Main(KytosNApp):
         self._storehouse_lock = Lock()
         self._flow_mods_sent_lock = Lock()
         self._check_consistency_exec_at = {}
-        self._check_consistency_locks = defaultdict(Lock)
+        self._check_consistency_lock = Lock()
 
         self._pending_barrier_reply = defaultdict(OrderedDict)
         self._pending_barrier_lock = Lock()
@@ -253,7 +253,7 @@ class Main(KytosNApp):
         """Check consistency of stored and installed flows given a switch."""
         if not ENABLE_CONSISTENCY_CHECK or not switch.is_enabled():
             return
-        with self._check_consistency_locks[switch.id]:
+        with self._check_consistency_lock:
             exec_at = self._check_consistency_exec_at.get(
                 switch.id, "0001-01-01T00:00:00"
             )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.5.0"
+NAPP_VERSION = "5.6.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"


### PR DESCRIPTION
Fixes #57 

### Description of the change

#### Added

- Added an upper bound rotating limit for the number of barrier replies, [like we have for flow mods](https://github.com/kytos-ng/flow_manager/blob/master/main.py#L721) stored in memory. In the future, this will be moved to a NoSQL DB.

#### Changed
- Changed ``_flow_mods_sent_error_locks``, ``_pending_barrier_locks``, and ``_check_consistency_lock`` to be safer using a single lock based on what we currently have
