### PR TITLE
[Feature] Retry connection errors before sending `kytos/flow_manager.flow.error`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = .eggs/*,.tox/*,*tests*,setup.py,.direnv/*,.venv/*,venv/*,v0x01/match.py
+omit = .eggs/*,.tox/*,*tests*,setup.py,.direnv/*,.venv/*,venv/*,v0x01/match.py,serializers/v0x01.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,16 @@ Removed
 Security
 ========
 
+[5.6.0] - 2021-12-15
+********************
+
+Added
+=====
+- Added support for retrying ``kytos/core.openflow.connection.error``
+- Added new high level error event ``kytos/flow_manager.openflow.connection.error`` 
+- Added retry configuration options
+
+
 [5.5.0] - 2021-11.24
 ********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,6 @@ Changed
 =======
 - Changed ``_flow_mods_sent_error_locks``, ``_pending_barrier_locks``, and ``_check_consistency_locks`` to be safer
 
->>>>>>> feature/barrier_upper_bound
 [5.5.0] - 2021-11.24
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -278,7 +278,7 @@ class Main(KytosNApp):
             send_barrier (bool): True to send barrier requests.
 
         Returns:
-            bool: True if retried, False if suceeded.
+            bool: True if retried, False if max retries have been reached.
         """
         if max_retries <= 0:
             raise ValueError(f"max_retries: {max_retries} should be > 0")

--- a/main.py
+++ b/main.py
@@ -28,6 +28,9 @@ from kytos.core.helpers import get_time, listen_to, now
 from .barrier_request import new_barrier_request
 from .exceptions import InvalidCommandError, SwitchNotConnectedError
 from .settings import (
+    CONN_ERR_MAX_RETRIES,
+    CONN_ERR_MIN_WAIT,
+    CONN_ERR_MULTIPLIER,
     CONSISTENCY_COOKIE_IGNORED_RANGE,
     CONSISTENCY_TABLE_ID_IGNORED_RANGE,
     ENABLE_BARRIER_REQUEST,
@@ -37,8 +40,8 @@ from .settings import (
 from .utils import (
     _valid_consistency_ignored,
     cast_fields,
-    new_flow_dict,
     get_min_wait_diff,
+    new_flow_dict,
 )
 
 
@@ -257,9 +260,9 @@ class Main(KytosNApp):
     def _retry_on_openflow_connection_error(
         self,
         event,
-        max_retries=3,
-        min_wait=0.2,
-        multiplier=2,
+        max_retries=CONN_ERR_MAX_RETRIES,
+        min_wait=CONN_ERR_MIN_WAIT,
+        multiplier=CONN_ERR_MULTIPLIER,
         send_barrier=ENABLE_BARRIER_REQUEST,
     ):
         """Try to retry on openflow connection error event."""

--- a/main.py
+++ b/main.py
@@ -881,7 +881,7 @@ class Main(KytosNApp):
         self._send_napp_event(
             switch,
             flow,
-            "connection_error",
+            "error",
             **error_kwargs,
         )
 

--- a/main.py
+++ b/main.py
@@ -312,8 +312,9 @@ class Main(KytosNApp):
             if wait_diff:
                 time.sleep(wait_diff)
             log.info(
-                f"Retry attempt: {count + 1} for xid: {xid}, accumulated wait: "
-                f"{wait_acc}, command: {command}, flow: {flow.as_dict()}"
+                f"Retry attempt: {count + 1} for xid: {xid} on switch: {switch.id}, "
+                f"accumulated wait: " f"{wait_acc}, command: {command}, "
+                f"flow: {flow.as_dict()}"
             )
             flow_mod = self.build_flow_mod_from_command(flow, command)
             flow_mod.header.xid = xid

--- a/main.py
+++ b/main.py
@@ -305,15 +305,18 @@ class Main(KytosNApp):
                 return False
 
             datetime_t2 = now()
-            wait_acc *= multiplier
-            self._flow_mods_retry_count[xid] = (count + 1, datetime_t2, wait_acc)
+            self._flow_mods_retry_count[xid] = (
+                count + 1,
+                datetime_t2,
+                wait_acc * multiplier,
+            )
         try:
             wait_diff = get_min_wait_diff(datetime_t2, sent_at, wait_acc)
             if wait_diff:
                 time.sleep(wait_diff)
             log.info(
                 f"Retry attempt: {count + 1} for xid: {xid} on switch: {switch.id}, "
-                f"accumulated wait: " f"{wait_acc}, command: {command}, "
+                f"accumulated wait: {wait_acc}, command: {command}, "
                 f"flow: {flow.as_dict()}"
             )
             flow_mod = self.build_flow_mod_from_command(flow, command)

--- a/main.py
+++ b/main.py
@@ -856,27 +856,6 @@ class Main(KytosNApp):
             **error_kwargs,
         )
 
-    def _on_openflow_connection_error(self, event):
-        """Publish core.openflow.connection.error."""
-        switch = event.content["destination"].switch
-        flow = event.message
-        try:
-            _, error_command = self._flow_mods_sent[event.message.header.xid]
-        except KeyError:
-            error_command = "unknown"
-        error_kwargs = {
-            "error_command": error_command,
-            "error_exception": event.content.get("exception"),
-        }
-        with self._flow_mods_sent_error_locks[switch.id]:
-            self._flow_mods_sent_error[int(event.message.header.xid)] = error_kwargs
-        self._send_napp_event(
-            switch,
-            flow,
-            "error",
-            **error_kwargs,
-        )
-
     @listen_to(".*.of_core.*.ofpt_error")
     def on_handle_errors(self, event):
         """Receive OpenFlow error and send a event.

--- a/main.py
+++ b/main.py
@@ -745,7 +745,7 @@ class Main(KytosNApp):
             raise FailedDependency(str(error))
 
     @classmethod
-    def build_flow_mod_from_command(self, flow, command):
+    def build_flow_mod_from_command(cls, flow, command):
         """Build a FlowMod serialized given a command."""
         if command == "delete":
             flow_mod = flow.as_of_delete_flow_mod()
@@ -861,8 +861,8 @@ class Main(KytosNApp):
         """Listen to openflow connection error and publish the flow error."""
         try:
             self._retry_on_openflow_connection_error(event)
-        except ValueError as e:
-            log.error(str(e))
+        except ValueError as exc:
+            log.error(str(exc))
 
     def _send_openflow_connection_error(self, event):
         """Publish kytos/flow_manager.flow.error with an error_exception."""

--- a/settings.py
+++ b/settings.py
@@ -12,3 +12,8 @@ ENABLE_BARRIER_REQUEST = True
 # To filter by a cookie or `table_id` range [(value1, value2)]
 CONSISTENCY_COOKIE_IGNORED_RANGE = []
 CONSISTENCY_TABLE_ID_IGNORED_RANGE = []
+
+# Retries options for `kytos/core.openflow.connection.error`
+CONN_ERR_MAX_RETRIES = 3
+CONN_ERR_MIN_WAIT = 0.2  # minimum wait between iterations in seconds
+CONN_ERR_MULTIPLIER = 2  # multiplier for the accumulated wait on each iteration

--- a/settings.py
+++ b/settings.py
@@ -15,5 +15,5 @@ CONSISTENCY_TABLE_ID_IGNORED_RANGE = []
 
 # Retries options for `kytos/core.openflow.connection.error`
 CONN_ERR_MAX_RETRIES = 3
-CONN_ERR_MIN_WAIT = 0.5  # minimum wait between iterations in seconds
+CONN_ERR_MIN_WAIT = 1  # minimum wait between iterations in seconds
 CONN_ERR_MULTIPLIER = 2  # multiplier for the accumulated wait on each iteration

--- a/settings.py
+++ b/settings.py
@@ -15,5 +15,5 @@ CONSISTENCY_TABLE_ID_IGNORED_RANGE = []
 
 # Retries options for `kytos/core.openflow.connection.error`
 CONN_ERR_MAX_RETRIES = 3
-CONN_ERR_MIN_WAIT = 0.2  # minimum wait between iterations in seconds
+CONN_ERR_MIN_WAIT = 0.5  # minimum wait between iterations in seconds
 CONN_ERR_MULTIPLIER = 2  # multiplier for the accumulated wait on each iteration

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.5.0"
+NAPP_VERSION = "5.6.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -35,9 +35,9 @@ class TestUtils(TestCase):
     def test_get_min_wait_diff_early_return(self):
         """Test get_min_wait diff early return."""
         test_data = [(1, 2, 3), (3, 4, 0)]
-        for t2, t1, min_wait in test_data:
-            with self.subTest(t2=t2, t1=t1, min_wait=min_wait):
-                assert get_min_wait_diff(t2, t1, min_wait) == 0
+        for dt_t2, dt_t1, min_wait in test_data:
+            with self.subTest(dt_t2=dt_t2, dt_t1=dt_t1, min_wait=min_wait):
+                assert get_min_wait_diff(dt_t2, dt_t1, min_wait) == 0
 
     def test_get_min_wait_diff(self):
         """Test get_min_wait diff values."""
@@ -45,8 +45,9 @@ class TestUtils(TestCase):
             (timedelta(seconds=8), timedelta(seconds=2), 4),
             (timedelta(seconds=8), timedelta(seconds=2), 6),
         ]
-        for t2, t1, min_wait in test_data:
-            with self.subTest(t2=t2, t1=t1, min_wait=min_wait):
-                get_min_wait_diff(t2, t1, min_wait) == (
-                    t2 - t1
-                ).total_seconds() - min_wait
+        for dt_t2, dt_t1, min_wait in test_data:
+            with self.subTest(dt_t2=dt_t2, dt_t1=dt_t1, min_wait=min_wait):
+                assert (
+                    get_min_wait_diff(dt_t2, dt_t1, min_wait)
+                    == (dt_t2 - dt_t1).total_seconds() - min_wait
+                )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,12 @@
 """Module to test the utils module."""
+from datetime import timedelta
 from unittest import TestCase
 
-from napps.kytos.flow_manager.utils import _valid_consistency_ignored, _validate_range
+from napps.kytos.flow_manager.utils import (
+    _valid_consistency_ignored,
+    _validate_range,
+    get_min_wait_diff,
+)
 
 
 class TestUtils(TestCase):
@@ -26,3 +31,22 @@ class TestUtils(TestCase):
         for values in test_data:
             with self.subTest(values=values):
                 assert not _valid_consistency_ignored(values)
+
+    def test_get_min_wait_diff_early_return(self):
+        """Test get_min_wait diff early return."""
+        test_data = [(1, 2, 3), (3, 4, 0)]
+        for t2, t1, min_wait in test_data:
+            with self.subTest(t2=t2, t1=t1, min_wait=min_wait):
+                assert get_min_wait_diff(t2, t1, min_wait) == 0
+
+    def test_get_min_wait_diff(self):
+        """Test get_min_wait diff values."""
+        test_data = [
+            (timedelta(seconds=8), timedelta(seconds=2), 4),
+            (timedelta(seconds=8), timedelta(seconds=2), 6),
+        ]
+        for t2, t1, min_wait in test_data:
+            with self.subTest(t2=t2, t1=t1, min_wait=min_wait):
+                get_min_wait_diff(t2, t1, min_wait) == (
+                    t2 - t1
+                ).total_seconds() - min_wait

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,7 +34,11 @@ class TestUtils(TestCase):
 
     def test_get_min_wait_diff_early_return(self):
         """Test get_min_wait diff early return."""
-        test_data = [(1, 2, 3), (3, 4, 0)]
+        test_data = [
+            (timedelta(seconds=1), timedelta(seconds=2), 3),
+            (timedelta(seconds=4), timedelta(seconds=3), 0),
+            (timedelta(seconds=8), timedelta(seconds=2), 4),
+        ]
         for dt_t2, dt_t1, min_wait in test_data:
             with self.subTest(dt_t2=dt_t2, dt_t1=dt_t1, min_wait=min_wait):
                 assert get_min_wait_diff(dt_t2, dt_t1, min_wait) == 0
@@ -42,12 +46,12 @@ class TestUtils(TestCase):
     def test_get_min_wait_diff(self):
         """Test get_min_wait diff values."""
         test_data = [
-            (timedelta(seconds=8), timedelta(seconds=2), 4),
-            (timedelta(seconds=8), timedelta(seconds=2), 6),
+            (timedelta(seconds=3), timedelta(seconds=2), 4),
+            (timedelta(seconds=5), timedelta(seconds=2), 6),
         ]
         for dt_t2, dt_t1, min_wait in test_data:
             with self.subTest(dt_t2=dt_t2, dt_t1=dt_t1, min_wait=min_wait):
                 assert (
                     get_min_wait_diff(dt_t2, dt_t1, min_wait)
-                    == (dt_t2 - dt_t1).total_seconds() - min_wait
+                    == min_wait - (dt_t2 - dt_t1).total_seconds()
                 )

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 """kytos/flow_manager utils."""
-import time
 
 from pyof.foundation.base import UBIntBase
 

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 """kytos/flow_manager utils."""
+import time
 
 from pyof.foundation.base import UBIntBase
 
@@ -66,3 +67,14 @@ def _valid_consistency_ignored(consistency_ignored_list):
             log.warn(msg, error_msg)
             return False
     return True
+
+
+def get_min_wait_diff(datetime_t2, datetime_t1, min_wait):
+    """Compute the min wait diff given two datetimes in secs, where t2 >= t1 in secs."""
+    if (datetime_t2 <= datetime_t1) or min_wait <= 0:
+        return 0
+    datetime_diff = (datetime_t2 - datetime_t1).total_seconds()
+    min_wait_diff = datetime_diff - min_wait
+    if min_wait_diff <= 0:
+        return 0
+    return min_wait_diff

--- a/utils.py
+++ b/utils.py
@@ -73,7 +73,7 @@ def get_min_wait_diff(datetime_t2, datetime_t1, min_wait):
     if (datetime_t2 <= datetime_t1) or min_wait <= 0:
         return 0
     datetime_diff = (datetime_t2 - datetime_t1).total_seconds()
-    min_wait_diff = datetime_diff - min_wait
+    min_wait_diff = min_wait - datetime_diff
     if min_wait_diff <= 0:
         return 0
     return min_wait_diff


### PR DESCRIPTION
Fixes #56 

### Description of the change

 Added support for asynchronously retrying temporary connection errors from `kytos/core.openflow.connection.error`, and publishing a `kytos/flow_manager.flow.error` error with a key `error_exception` set, that way enhancing handling potential connection outages and facilitating for subscribers in terms of temporary error handling, so up to this point, whenever subscribers get a `kytos/flow_manager.flow.error` they can differentiate and react accordingly. 

### Release notes

`[5.7.0] - 2021-12-15`

#### Added
- Added support for retrying ``kytos/core.openflow.connection.error``
- Added retry configuration options with default values

### Execution sample

Here's an execution simulating connection errors when `mef_eline` is trying to create an EVC: 

```
2021-12-17 16:32:36,520 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_14) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:36,563 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_65) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,119 - INFO [kytos.napps.kytos/flow_manager] (Thread-17) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True, flows_dict: {'flows':
 [{'cookie': 12287216144691400267, 'cookie_mask': 18446744073709551615}], 'force': True}
2021-12-17 16:32:39,127 - INFO [kytos.napps.kytos/flow_manager] (Thread-18) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True, flows_dict: {'flows':
 [{'cookie': 12287216144691400267, 'cookie_mask': 18446744073709551615}], 'force': True}
2021-12-17 16:32:39,135 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_44) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,138 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_163) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,140 - INFO [kytos.napps.kytos/mef_eline] (Thread-16) EVC 84f5fbaec68e4b was synced to the storehouse.
2021-12-17 16:32:39,166 - INFO [kytos.napps.kytos/flow_manager] (Thread-20) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False, flows_dict: {'flows': [
{'match': {'in_port': 2, 'dl_vlan': 2808}, 'cookie': 12287216144691400267, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 1341},{'action_type': 'output', 'port': 3}]}, {'match': {'in_port': 3, 'dl_vlan': 1341}, 'cookie': 12287216144691400267, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 2808}, {'action_type': 'output', 'port': 2}]}], 'force': False}
2021-12-17 16:32:39,184 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_165) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,188 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_170) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,188 - INFO [kytos.napps.kytos/flow_manager] (Thread-21) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [{'match': {'in_port': 1}, 'cookie': 12287216144691400267, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2808}, {'action_type': 'output', 'port': 2}]}, {'match': {'in_port': 2, 'dl_vlan': 2808}, 'cookie': 12287216144691400267, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}]}], 'force': False}

```

Notice the `connection closed error from kytos core`:

```
2021-12-17 16:32:39,191 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2021-12-17 16:32:39,194 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
```

```
2021-12-17 16:32:39,202 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_174) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,204 - INFO [kytos.napps.kytos/flow_manager] (Thread-22) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False, flows_dict: {'flows': [{'match': {'in_port': 1}, 'cookie': 12287216144691400267, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1341}, {'action_type': 'output', 'port': 2}]}, {'match': {'in_port': 2, 'dl_vlan': 1341}, 'cookie': 12287216144691400267, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}]}], 'force': False}
2021-12-17 16:32:39,213 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_179) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,219 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_182) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,219 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_179) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,227 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_92) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,229 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_40) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,231 - INFO [kytos.napps.kytos/mef_eline] (Thread-16) EVC 84f5fbaec68e4b was synced to the storehouse.
2021-12-17 16:32:39,232 - INFO [kytos.napps.kytos/mef_eline] (Thread-16) EVC(84f5fbaec68e4b, evc1) was deployed.
2021-12-17 16:32:39,238 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_87) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,249 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_173) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,267 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_183) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:39,279 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_166) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
```

Asynchronous retry on `flow_manager` kicks in:

```
2021-12-17 16:32:40,198 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_175) Retry attempt: 1 for xid: 3209996045 on switch: 00:00:00:00:00:00:00:01, accumulated wait: 1,
 command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267, 'id': '7a8c67f849f9b087d619c7615b00ba70', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'vlan_id': 2808, 'action_type': 'set_vlan'}, {'port': 2, 'action_type': 'output'}]}]}
2021-12-17 16:32:40,199 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_176) Retry attempt: 1 for xid: 229786217 on switch: 00:00:00:00:00:00:00:01, accumulated wait: 1,
command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 2, 'dl_vlan': 2808}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267, 'id': '5744d85337445b8ee4a3cb7d39a37272', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_vla
n'}, {'port': 1, 'action_type': 'output'}]}]}
2021-12-17 16:32:40,200 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2021-12-17 16:32:40,201 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2021-12-17 16:32:40,210 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_194) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:40,212 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_0) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
kytos $>

kytos $> 2021-12-17 16:32:41,201 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_190) Retry attempt: 2 for xid: 3209996045 on switch: 00:00:00:00:00:00:00:01, accumulated
 wait: 2, command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 32768,'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267, 'id': '7a8c67f849f9b087d619c7615b00ba70', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_vlan', 't
ag_type': 's'}, {'vlan_id': 2808, 'action_type': 'set_vlan'}, {'port': 2, 'action_type': 'output'}]}]}
2021-12-17 16:32:41,207 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2021-12-17 16:32:41,209 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_20) Retry attempt: 2 for xid: 229786217 on switch: 00:00:00:00:00:00:00:01, accumulated wait: 2, c
ommand: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 2, 'dl_vlan': 2808}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267, 'id': '5744d85337445b8ee4a3cb7d39a37272', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_vlan'}, {'port': 1, 'action_type': 'output'}]}]}
2021-12-17 16:32:41,213 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2021-12-17 16:32:41,251 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_1) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5
2021-12-17 16:32:41,255 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_105) Flow saved in kytos.flow.persistence.d91ce6555cec43649d8759f0b64e5cf5


kytos $>

kytos $> 2021-12-17 16:32:44,207 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_214) Retry attempt: 3 for xid: 229786217 on switch: 00:00:00:00:00:00:00:01, accumulated
wait: 4, command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 2, 'dl_vlan': 2808}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'co
okie': 12287216144691400267, 'id': '5744d85337445b8ee4a3cb7d39a37272', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type':
 'pop_vlan'}, {'port': 1, 'action_type': 'output'}]}]}
2021-12-17 16:32:44,211 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
2021-12-17 16:32:44,221 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_213) Retry attempt: 3 for xid: 3209996045 on switch: 00:00:00:00:00:00:00:01, accumulated wait: 4,
 command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267, 'id': '7a8c67f849f9b087d619c7615b00ba70', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_vlan', 'tag_type':'s'}, {'vlan_id': 2808, 'action_type': 'set_vlan'}, {'port': 2, 'action_type': 'output'}]}]}
2021-12-17 16:32:44,224 - INFO [kytos.core.controller] (MainThread) connection closed. Cannot send message
```

Max retries have will be reached, and finally `mef_eline` (subscribing to `kytos/flow_manager.flow.error`) will get the event with the key set `'error_exception': 'Connection state: ConnectionState.ESTABLISHED'`

```
2021-12-17 16:32:44,225 - WARNING [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_236) Max retries: 3 for xid: 229786217 has been reached on switch 00:00:00:00:00:00:00:01, comm
and: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 2, 'dl_vlan': 2808}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267, 'id': '5744d85337445b8ee4a3cb7d39a37272', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_vlan'}, {'port': 1, 'action_type': 'output'}]}]}
2021-12-17 16:32:44,228 - WARNING [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_238) Max retries: 3 for xid: 3209996045 has been reached on switch 00:00:00:00:00:00:00:01, com
mand: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12287216144691400267,
'id': '7a8c67f849f9b087d619c7615b00ba70', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions','actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'vlan_id': 2808, 'action_type': 'set_vlan'}, {'port': 2, 'action_type': 'output'}]}]}
2021-12-17 16:32:44,230 - INFO [kytos.napps.kytos/mef_eline] (ThreadPoolExecutor-0_239) mef_eline got flow_mod_error: {'datapath': Switch('00:00:00:00:00:00:00:01'), 'flow': FlowMod(xi
d=229786217), 'error_command': 'add', 'error_exception': 'Connection state: ConnectionState.ESTABLISHED'}
2021-12-17 16:32:44,236 - INFO [kytos.napps.kytos/mef_eline] (ThreadPoolExecutor-0_127) mef_eline got flow_mod_error: {'datapath': Switch('00:00:00:00:00:00:00:01'), 'flow': FlowMod(xi
d=3209996045), 'error_command': 'add', 'error_exception': 'Connection state: ConnectionState.ESTABLISHED'}

```
