### PR TITLE
[Fix] Avoid skipping consistency check after a reconnection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,13 @@ Removed
 Security
 ========
 
+[5.7.1] - 2022-01-18
+********************
+
+Added
+=====
+- Subscribed to ``on_connection_lost`` event to reset consistency check executions
+
 [5.7.0] - 2021-12-15
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -144,10 +144,10 @@ class Main(KytosNApp):
                 self.resent_flows.add(dpid)
                 log.info(f"Flows resent to Switch {dpid}")
 
-    @listen_to('.*.connection.lost')
+    @listen_to(".*.connection.lost")
     def on_connection_lost(self, event):
         """On switch connection lost handler."""
-        switch = event.content['source'].switch
+        switch = event.content["source"].switch
         if not switch:
             return
         with self._check_consistency_lock:

--- a/main.py
+++ b/main.py
@@ -144,6 +144,19 @@ class Main(KytosNApp):
                 self.resent_flows.add(dpid)
                 log.info(f"Flows resent to Switch {dpid}")
 
+    @listen_to('.*.connection.lost')
+    def on_connection_lost(self, event):
+        """On switch connection lost handler."""
+        switch = event.content['source'].switch
+        if not switch:
+            return
+        with self._check_consistency_lock:
+            self.reset_check_consistency_exec(switch.id)
+
+    def reset_check_consistency_exec(self, dpid):
+        """Reset _check_consistency_exec_at for a dpid."""
+        self._check_consistency_exec_at.pop(dpid, None)
+
     @staticmethod
     def is_ignored(field, ignored_range):
         """Check that the flow field is in the range of ignored flows.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "5.7.0"
+NAPP_VERSION = "5.7.1"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1231,6 +1231,13 @@ class TestMain(TestCase):
                 self.napp.check_storehouse_consistency(switch)
                 self.assertEqual(mock_install_flows.call_count, called)
 
+    def test_reset_check_consistency_exec(self):
+        """Test on_ofpt_flow_removed."""
+        dpid = "00:00:00:00:00:00:00:01"
+        self.napp._check_consistency_exec_at[dpid] = 1
+        self.napp.reset_check_consistency_exec(dpid)
+        assert dpid not in self.napp._check_consistency_exec_at
+
     def test_check_consistency_concurrency_control(self):
         """Test check consistency concurrency control, only a single
         thread per switch is expected within a delta T."""


### PR DESCRIPTION
Fixes #63 

### Description of the change

Avoid skipping consistency check right after a reconnection

### Release notes

#### Added
- Subscribed to ``on_connection_lost`` event to reset consistency check executions


### Exec sample

- Now, after a reconnection, once the consistency check runs again, it won't skip:

```
2022-01-18 15:10:09,225 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:56106
2022-01-18 15:10:09,226 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:56108
2022-01-18 15:10:09,228 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:56110
2022-01-18 15:10:09,244 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_9) Connection ('127.0.0.1', 56108), Switch 00:00:00:00:00:00:00:03: OPENFLOW HANDSHAKE COMPLETE
2022-01-18 15:10:09,259 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_11) Connection ('127.0.0.1', 56110), Switch 00:00:00:00:00:00:00:02: OPENFLOW HANDSHAKE COMPLETE
2022-01-18 15:10:09,260 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_7) Connection ('127.0.0.1', 56106), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2022-01-18 15:10:09,262 - INFO [kytos.napps.kytos/flow_manager] (Thread-21) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False, flows_dict: {'flows': [{
'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677059, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-01-18 15:10:09,292 - INFO [kytos.napps.kytos/flow_manager] (Thread-24) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [{
'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-01-18 15:10:09,297 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_6) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
2022-01-18 15:10:09,298 - INFO [kytos.napps.kytos/flow_manager] (Thread-25) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False, flows_dict: {'flows': [{
'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677058, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-01-18 15:10:09,312 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_11) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
2022-01-18 15:10:09,319 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_10) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
2022-01-18 15:10:09,328 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_4) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
2022-01-18 15:10:09,360 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_0) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
2022-01-18 15:10:09,378 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_12) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
kytos $>

kytos $> 2022-01-18 15:10:12,258 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_11) check_consistency on switch 00:00:00:00:00:00:00:03 has started
2022-01-18 15:10:12,260 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_11) check_consistency on switch 00:00:00:00:00:00:00:03 is done
2022-01-18 15:10:15,278 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_9) check_consistency on switch 00:00:00:00:00:00:00:01 has started
2022-01-18 15:10:15,281 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_9) Consistency check: missing flow on switch 00:00:00:00:00:00:00:01.
2022-01-18 15:10:15,286 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_9) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be installed. Flow: {'flows': [{'priority':
10, 'match': {'in_port': 1, 'dl_vlan': 100}, 'actions': [{'action_type': 'output', 'port': 1}]}]}
2022-01-18 15:10:15,287 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_9) check_consistency on switch 00:00:00:00:00:00:00:01 is done
2022-01-18 15:10:15,289 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_4) Flow saved in kytos.flow.persistence.ce6105de23414a23ae35186f784a0a49
2022-01-18 15:10:18,279 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_5) check_consistency on switch 00:00:00:00:00:00:00:02 has started
2022-01-18 15:10:18,281 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_5) check_consistency on switch 00:00:00:00:00:00:00:02 is done
```
