### PR TITLE
Add Lock to prevent race conditions at flow_manager.storehouse

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,13 @@ Removed
 Security
 ========
 
+[2022.1.1] - 2022-02-04
+***********************
+
+Changed
+=======
+- Adding Lock to avoid race conditions at flow_manager's storehouse
+
 [2022.1.0] - 2022-02-02
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2022.1.0",
+  "version": "2022.1.1",
   "napp_dependencies": ["kytos/of_core", "kytos/storehouse"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "flow_manager"
-NAPP_VERSION = "2022.1.0"
+NAPP_VERSION = "2022.1.1"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/storehouse.py
+++ b/storehouse.py
@@ -88,6 +88,7 @@ class StoreHouse:
         else:
             self.create_box()
 
+    # pylint: disable=consider-using-with
     def get_stored_box(self, box_id):
         """Get persistence box from storehouse."""
         content = {
@@ -99,7 +100,7 @@ class StoreHouse:
         name = "kytos.storehouse.retrieve"
         event = KytosEvent(name=name, content=content)
         self._lock.acquire()  # Lock to avoid race condition
-        log.debug(f'Lock {self._lock} acquired.')
+        log.debug(f"Lock {self._lock} acquired.")
         self.controller.buffers.app.put(event)
 
     def _get_box_callback(self, _event, data, error):
@@ -109,8 +110,9 @@ class StoreHouse:
 
         self.box = data
         self._lock.release()
-        log.debug(f'Lock {self._lock} released.')
+        log.debug(f"Lock {self._lock} released.")
 
+    # pylint: disable=consider-using-with
     def save_flow(self, flows):
         """Save flows in storehouse."""
         self._lock.acquire()  # Lock to avoid race condition


### PR DESCRIPTION
Fix #67 

### Description of the change

This PR adds a `threading.Lock` mechanism to protect flow_manager's storehouse from race conditions in the save flows. The general idea of Lock protection follows the same logic already adopted by mef_eline and topology. 

After applying this PR, new tests were run to confirm the fix of issue #67 (following the same methodology described at kytos-ng/storehouse#9). Out of 20 repetitions, no failure was observed.

### Release notes

- Added Lock mechanism to protect flow_manager's  storehouse from race conditions.