### PR TITLE
[Fix] Updated README.rst 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 .. raw:: html
 
   <div align="center">
-    <h1><code>kytos-ng/flow_manager</code></h1>
+    <h1><code>kytos/flow_manager</code></h1>
 
     <strong>NApp that manages OpenFlow 1.3 entries</strong>
 


### PR DESCRIPTION
Updated the README.rst, now it has the same shields as `mef_eline`, and also, [you can view the rendered readme visiting this page](https://github.com/kytos-ng/flow_manager/tree/fix/update_readme):

- Added a centralized header component with a link to this NApp's OpenAPI spec 
- Added which major features are supported
- Updated events
- Updated how to install