### PR TITLE
[Feature] MongoDB `bulk_write` operations for `/api/kytos/flow_manager/v2/flows/`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 - Removed ``log.info`` send FlowMod from the request hot path for now
 - Refactored consistency check to leverage ``flow_id`` and ``match_id``
 - Refactored `flows` upsert and delete operations to use `bulk_write` instead for higher performance based on the expected workload
+- Endpoint /flow_manager/v2/flows/ writes first to the database now to optimize consistency for bulk operations.
 
 Deprecated
 ==========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 =======
 - Removed ``log.info`` send FlowMod from the request hot path for now
 - Refactored consistency check to leverage ``flow_id`` and ``match_id``
+- Refactored `flows` upsert and delete operations to use `bulk_write` instead for higher performance based on the expected workload
 
 Deprecated
 ==========

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -68,30 +68,6 @@ class FlowController:
             if self.mongo.bootstrap_index(collection, keys, **kwargs):
                 log.info(f"Created DB index {keys}, collection: {collection})")
 
-    def upsert_flow(self, match_id: str, flow_dict: dict) -> Optional[dict]:
-        """Update or insert flow.
-
-        Insertions and updates are indexed by match_id to minimize lookups.
-        """
-        utc_now = datetime.utcnow()
-        model = FlowDoc(
-            **{
-                **flow_dict,
-                **{"_id": match_id, "updated_at": utc_now},
-            }
-        )
-        payload = model.dict(exclude={"inserted_at"}, exclude_none=True)
-        updated = self.db.flows.find_one_and_update(
-            {"_id": match_id},
-            {
-                "$set": payload,
-                "$setOnInsert": {"inserted_at": utc_now},
-            },
-            return_document=ReturnDocument.AFTER,
-            upsert=True,
-        )
-        return updated
-
     def upsert_flows(self, match_ids: List[str], flow_dicts: List[dict]) -> dict:
         """Update or insert flows."""
         utc_now = datetime.utcnow()

--- a/main.py
+++ b/main.py
@@ -396,7 +396,12 @@ class Main(KytosNApp):
         If flows are matched, they will be bulk deleted.
         """
         flow_ids_to_delete = set()
-        cookies = list({int(value.get("cookie", 0)) for value in flow_dicts})
+        cookies = list(
+            {
+                int(value.get("cookie", 0)) & int(value.get("cookie_mask", 0))
+                for value in [flow.get("flow", {}) for flow in flow_dicts]
+            }
+        )
         for dpid, stored_flows in self.flow_controller.get_flows_by_cookies(
             list(switches.keys()), cookies
         ).items():

--- a/main.py
+++ b/main.py
@@ -410,7 +410,7 @@ class Main(KytosNApp):
                     if stored_flow["flow_id"] in flow_ids_to_delete:
                         continue
                     if match_flow(
-                        flow_dict,
+                        flow_dict["flow"],
                         switches[dpid].connection.protocol.version,
                         stored_flow["flow"],
                     ):

--- a/main.py
+++ b/main.py
@@ -413,23 +413,6 @@ class Main(KytosNApp):
             self.flow_controller.delete_flows_by_ids(list(flow_ids_to_delete))
 
     # pylint: disable=attribute-defined-outside-init
-    def _delete_matched_flows(self, flow_dict, _flow_id, _match_id, switch):
-        """Try to delete matching stored flows given a flow dict."""
-        cookie = flow_dict.get("cookie", 0)
-        stored_flows = self.flow_controller.get_flows_by_cookie(switch.id, cookie)
-        version = switch.connection.protocol.version
-        flow_ids = []
-        for flow in stored_flows:
-            if match_flow(flow_dict, version, flow["flow"]):
-                flow_ids.append(flow["flow_id"])
-        if flow_ids:
-            self.flow_controller.delete_flows_by_ids(flow_ids)
-
-    def _upsert_flow(self, flow_dict, flow_id, match_id, switch):
-        """Try to add a flow dict in the store idempotently."""
-        flow_dict = {**{"flow": flow_dict}, **{"switch": switch.id, "flow_id": flow_id}}
-        self.flow_controller.upsert_flow(match_id, flow_dict)
-
     @rest("v2/flows")
     @rest("v2/flows/<dpid>")
     def list(self, dpid=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ add-ignore = D105
 
 [yala]
 radon mi args = --min C
-pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments,too-many-public-methods,unnecessary-pass --ignored-modules=napps.kytos.topology
+pylint args = --disable==too-many-arguments,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments,too-many-public-methods,unnecessary-pass,import-error,relative-beyond-top-level --ignored-modules=napps.kytos.topology
 linters=pylint,pycodestyle,isort,black
 
 [flake8]

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -56,13 +56,6 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         indexes = [(v[0][0], v[0][1]) for v in mock.call_args_list]
         assert expected_indexes == indexes
 
-    def test_upsert_flow(self) -> None:
-        """Test upsert_flow."""
-        assert self.flow_controller.upsert_flow(self.match_id, self.flow_dict)
-        arg1, arg2 = self.flow_controller.db.flows.find_one_and_update.call_args[0]
-        assert arg1 == {"_id": self.match_id}
-        assert arg2["$set"]["flow"]
-
     def test_upsert_flows(self) -> None:
         """Test upsert_flows."""
         match_ids, flow_dicts = ["1", "2"], [

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -63,6 +63,17 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         assert arg1 == {"_id": self.match_id}
         assert arg2["$set"]["flow"]
 
+    def test_upsert_flows(self) -> None:
+        """Test upsert_flows."""
+        match_ids, flow_dicts = ["1", "2"], [
+            {"flow_id": "1", "switch": self.dpid, "flow": {"match": {"in_port": 1}}},
+            {"flow_id": "2", "switch": self.dpid, "flow": {"match": {"in_port": 2}}},
+        ]
+        assert self.flow_controller.upsert_flows(match_ids, flow_dicts)
+        assert self.flow_controller.db.flows.bulk_write.call_count == 1
+        args = self.flow_controller.db.flows.bulk_write.call_args[0]
+        assert len(args[0]) == len(flow_dicts)
+
     def test_update_flow_state(self) -> None:
         """Test update_flow_state."""
         assert self.flow_controller.update_flow_state(self.flow_id, "installed")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -542,8 +542,10 @@ class TestMain(TestCase):
         flow1.__getitem__.side_effect = flow1_dict.__getitem__
         flows = [flow1]
         switch.flows = flows
-        self.napp.flow_controller.get_flows_by_cookie.return_value = flows
-        self.napp._delete_matched_flows(flow1_dict, flow1.id, flow1.match_id, switch)
+        self.napp.flow_controller.get_flows_by_cookies.return_value = {
+            switch.id: [flow1_dict]
+        }
+        self.napp.delete_matched_flows([flow1_dict], {switch.id: switch})
         self.napp.flow_controller.delete_flows_by_ids.assert_called_with([flow1.id])
 
     def test_add_barrier_request(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,9 +2,12 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
-from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
 
-from napps.kytos.flow_manager.exceptions import SwitchNotConnectedError
+from napps.kytos.flow_manager.exceptions import (
+    InvalidCommandError,
+    SwitchNotConnectedError,
+)
+from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
 
 from kytos.core.helpers import now
 from kytos.lib.helpers import (

--- a/tests/unit/test_match_13.py
+++ b/tests/unit/test_match_13.py
@@ -30,6 +30,15 @@ from napps.kytos.flow_manager.v0x04.match import _match_cookie, match13_no_stric
             },
             False,
         ),
+        (
+            {"match": {"in_port": 5, "dl_vlan": 3201}},
+            {
+                "cookie": 0,
+                "match": {"dl_src": "ee:ee:ee:ee:ee:02"},
+                "priority": 50000,
+            },
+            False,
+        ),
     ],
 )
 def test_no_strict_delete_in_port(to_install, stored, should_match) -> None:

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,37 @@
 """kytos/flow_manager utils."""
 
 from pyof.foundation.base import UBIntBase
+from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
 
 from kytos.core import log
+
+from .exceptions import InvalidCommandError
+
+
+def build_flow_mod_from_command(flow, command):
+    """Build a FlowMod serialized given a command."""
+    if command == "delete":
+        flow_mod = flow.as_of_delete_flow_mod()
+    elif command == "delete_strict":
+        flow_mod = flow.as_of_strict_delete_flow_mod()
+    elif command == "add":
+        flow_mod = flow.as_of_add_flow_mod()
+    else:
+        raise InvalidCommandError
+    return flow_mod
+
+
+def build_command_from_flow_mod(flow_mod) -> str:
+    """Build a command str given a FlowMod."""
+    commands = {
+        FlowModCommand.OFPFC_ADD.value: "add",
+        FlowModCommand.OFPFC_DELETE.value: "delete",
+        FlowModCommand.OFPFC_DELETE_STRICT.value: "delete_strict",
+    }
+    try:
+        return commands[flow_mod.command.value]
+    except KeyError:
+        return str(flow_mod.command.value)
 
 
 def is_ignored(field, ignored_range):


### PR DESCRIPTION
Fixes #80 

### Description of the change

- Refactored `flows` upsert and delete operations to use `bulk_write` instead for higher performance based on the expected workload
- Endpoint /flow_manager/v2/flows/ writes first to the database now to optimize consistency for bulk operations

This table summarize the ratio of performance gains comparing this branch `feature/bulk_ops` with `feature/mongo`, the number of DB operations are no longer proportional of the number of flows in the body but constant to the number of the request. For upserts (update or insert) with 3 flows, the gains are significant, 100x faster comparing the 95 percentile. For deletions, it's 10x faster comparing the 95 percentile. For a single flow it's relatively the same:

![2022-05-26-124839_1539x323_scrot](https://user-images.githubusercontent.com/1010796/170525769-425885f6-7a6d-4290-85aa-e5e9bb8180a1.png)

## Stress test

To measure the performance, it was stress tested with 50 req / sec during 60 secs with the following payloads, Elastic APM was also actively used to monitor the DB operators performance (but to minimize the information I'm only posting the primary information here):

### POST 50 req/sec with 1 flows, branch `feature/bulk_ops`

```
❯ jq -ncM '{method: "POST", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_port"
 : 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] } ] } | @base64, header: {"Content-Type": ["application/json"]}}' | vegeta attack -format=json -rate 50/1s -
duration=60s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         3000, 50.02, 50.01
Duration      [total, attack, wait]             59.99s, 59.981s, 9.965ms
Latencies     [min, mean, 50, 90, 95, 99, max]  5.25ms, 21.683ms, 13.116ms, 47.324ms, 64.941ms, 105.676ms, 256.573ms
Bytes In      [total, mean]                     111000, 37.00
Bytes Out     [total, mean]                     366000, 122.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:3000
Error Set:
```

### POST 50 req/sec with 1 flow, branch `feature/mongo`

```
❯ jq -ncM '{method: "POST", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_port"
 : 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] } ] } | @base64, header: {"Content-Type": ["application/json"]}}' | vegeta attack -format=json -rate 50/1s -
duration=60s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         3000, 50.02, 50.01
Duration      [total, attack, wait]             59.99s, 59.98s, 9.965ms
Latencies     [min, mean, 50, 90, 95, 99, max]  5.256ms, 19.966ms, 12.204ms, 45.041ms, 58.235ms, 88.72ms, 150.608ms
Bytes In      [total, mean]                     111000, 37.00
Bytes Out     [total, mean]                     366000, 122.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:3000
Error Set:
```

### POST 50 req/sec with 3 flows, branch `feature/bulk_ops`


```
❯ jq -ncM '{method: "POST", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_port"
 : 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 101 }, "actions": [ { "action_type": "output", "por
t": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 102 }, "actions": [ { "action_type": "output", "port": 1 } ] } ] } | @base64, header: {"Content-Type": ["application/js
on"]}}' | vegeta attack -format=json -rate 50/1s -duration=60s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         3000, 50.02, 50.00
Duration      [total, attack, wait]             59.998s, 59.979s, 18.393ms
Latencies     [min, mean, 50, 90, 95, 99, max]  6.819ms, 27.887ms, 18.707ms, 52.68ms, 75.7ms, 140.392ms, 220.288ms
Bytes In      [total, mean]                     111000, 37.00
Bytes Out     [total, mean]                     954000, 318.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:3000
Error Set:
```

### POST 50 req/sec with 3 flows, branch `feature/mongo`


```
❯ jq -ncM '{method: "POST", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_port"
 : 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 101 }, "actions": [ { "action_type": "output", "por
t": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 102 }, "actions": [ { "action_type": "output", "port": 1 } ] } ] } | @base64, header: {"Content-Type": ["application/js
on"]}}' | vegeta attack -format=json -rate 50/1s -duration=60s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         3000, 50.02, 46.14
Duration      [total, attack, wait]             1m5s, 59.98s, 5.04s
Latencies     [min, mean, 50, 90, 95, 99, max]  15.647ms, 3.779s, 3.92s, 8.09s, 8.639s, 9.485s, 10.683s
Bytes In      [total, mean]                     111000, 37.00
Bytes Out     [total, mean]                     954000, 318.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:3000
Error Set:
```


### DELETE 50 req/sec with 3 flows, branch `feature/bulk_ops`


```
❯ jq -ncM '{method: "DELETE", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_por
t" : 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 101 }, "actions": [ { "action_type": "output", "p
ort": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 102 }, "actions": [ { "action_type": "output", "port": 1 } ] } ] } | @base64, header: {"Content-Type": ["application/
json"]}}' | vegeta attack -format=json -rate 50/1s -duration=60s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         3000, 50.02, 50.01
Duration      [total, attack, wait]             59.994s, 59.98s, 13.311ms
Latencies     [min, mean, 50, 90, 95, 99, max]  4.53ms, 55.919ms, 14.976ms, 84.775ms, 214.355ms, 929.206ms, 1.414s
Bytes In      [total, mean]                     111000, 37.00
Bytes Out     [total, mean]                     954000, 318.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:3000
Error Set:
```

### DELETE 50 req/sec with 3 flows, branch `feature/mongo`


```
❯ jq -ncM '{method: "DELETE", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_por
t" : 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 101 }, "actions": [ { "action_type": "output", "p
ort": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 102 }, "actions": [ { "action_type": "output", "port": 1 } ] } ] } | @base64, header: {"Content-Type": ["application/
json"]}}' | vegeta attack -format=json -rate 50/1s -duration=60s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         3000, 50.02, 50.00
Duration      [total, attack, wait]             59.996s, 59.98s, 16.651ms
Latencies     [min, mean, 50, 90, 95, 99, max]  8.645ms, 413.429ms, 51.541ms, 1.36s, 2.169s, 3.661s, 6.399s
Bytes In      [total, mean]                     111000, 37.00
Bytes Out     [total, mean]                     954000, 318.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:3000
Error Set:
```

