### PR TITLE
Update setup and dependencies to be compatible with py39 and fix conflicts

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,6 +209,7 @@ class Main(KytosNApp):
             return
         self._on_ofpt_barrier_reply(event)
 
+    # pylint: disable=pointless-string-statement
     def _on_ofpt_barrier_reply(self, event):
         """Process on_ofpt_barrier_reply event."""
         switch = event.source.switch
@@ -714,11 +715,15 @@ class Main(KytosNApp):
         return jsonify(switch_flows)
 
     @listen_to("kytos.flow_manager.flows.(install|delete)")
-    def event_flows_install_delete(self, event):
+    def on_flows_install_delete(self, event):
         """Install or delete flows in the switches through events.
 
         Install or delete Flow of switches identified by dpid.
         """
+        self.handle_flows_install_delete(event)
+
+    def handle_flows_install_delete(self, event):
+        """Handle install/delete flows event."""
         try:
             dpid = event.content["dpid"]
             flow_dict = event.content["flow_dict"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,7 @@ click==8.0.3
     #   pip-tools
 coverage==6.1.1
     # via kytos-flow-manager
-dataclasses==0.8
+dataclasses==0.8; python_version < "3.7"
     # via black
 decorator==4.4.2
     # via
@@ -198,7 +198,7 @@ typed-ast==1.4.3
     # via
     #   astroid
     #   black
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   astroid
     #   black

--- a/setup.py
+++ b/setup.py
@@ -287,6 +287,7 @@ setup(
     install_requires=read_requirements(),
     setup_requires=["pytest-runner"],
     tests_require=["pytest==7.0.0"],
+    packages=[],
     extras_require={
         "dev": [
             "coverage",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -312,7 +312,7 @@ class TestMain(TestCase):
             name="kytos.flow_manager.flows.install",
             content={"dpid": dpid, "flow_dict": mock_flow_dict},
         )
-        self.napp.event_flows_install_delete(event)
+        self.napp.handle_flows_install_delete(event)
         mock_install_flows.assert_called_with(
             "add", mock_flow_dict, [switch], reraise_conn=True
         )
@@ -328,7 +328,7 @@ class TestMain(TestCase):
             name="kytos.flow_manager.flows.delete",
             content={"dpid": dpid, "flow_dict": mock_flow_dict},
         )
-        self.napp.event_flows_install_delete(event)
+        self.napp.handle_flows_install_delete(event)
         mock_install_flows.assert_called_with(
             "delete", mock_flow_dict, [switch], reraise_conn=True
         )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -333,6 +333,48 @@ class TestMain(TestCase):
             "delete", mock_flow_dict, [switch], reraise_conn=True
         )
 
+    @patch("napps.kytos.flow_manager.main.log")
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    @patch("napps.kytos.flow_manager.main.Main._send_napp_event")
+    def test_handle_flows_install_delete_fail(self, *args):
+        """Test handle_flows_install_delete with failure scenarios."""
+        (mock_send_napp_event, mock_install_flows, mock_log) = args
+        dpid = "00:00:00:00:00:00:00:01"
+        self.napp.controller.switches = {}
+        mock_flow_dict = MagicMock()
+
+        # 723, 746-751, 873
+        # missing event args
+        event = get_kytos_event_mock(
+            name="kytos.flow_manager.flows.delete",
+            content={},
+        )
+        self.napp.handle_flows_install_delete(event)
+        mock_log.error.assert_called()
+
+        # invalid command
+        event = get_kytos_event_mock(
+            name="kytos.flow_manager.flows.xpto",
+            content={"dpid": dpid, "flow_dict": mock_flow_dict},
+        )
+        with self.assertRaises(ValueError):
+            self.napp.handle_flows_install_delete(event)
+
+        # install_flow exceptions
+        event = get_kytos_event_mock(
+            name="kytos.flow_manager.flows.install",
+            content={"dpid": dpid, "flow_dict": mock_flow_dict},
+        )
+        mock_install_flows.side_effect = InvalidCommandError("error")
+        mock_log.error.call_count = 0
+        self.napp.handle_flows_install_delete(event)
+        mock_log.error.assert_called()
+        mock_install_flows.side_effect = SwitchNotConnectedError(
+            "error", flow=MagicMock()
+        )
+        self.napp.handle_flows_install_delete(event)
+        mock_send_napp_event.assert_called()
+
     def test_add_flow_mod_sent(self):
         """Test _add_flow_mod_sent method."""
         xid = 0


### PR DESCRIPTION
Fixes #84 

### Description of the change

- Update setup to make flow_manager compatible with py39, as per comment https://github.com/kytos-ng/flow_stats/pull/18#discussion_r852213307
- Adding conditional to install dataclasses only on python < 3.7 (PEP 557)
- Fix dependency conflicts with kytos (typing-extensions)
- Fix unit tests that were failing after first call due to threaded listen_to methods direct call (using the strategy of on_event/handle_event)
- Adding a few unit tests to increase coverage

### Change log

N/A