### PR TITLE
[Feature] log.info entry for `kytos.flow_manager.flows.(install|delete)` handler for troubleshooting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 - Consistency checks executions are stored on MongoDB flow_checks collection
 - FlowController and DB models
 - ``scripts/storehouse_to_mongo.py`` script to migrate data from storehouse to MongoDB
+- Added log.info entry for kytos.flow_manager.flows.(install|delete) handler for troubleshooting
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -469,6 +469,10 @@ class Main(KytosNApp):
 
         force = bool(event.content.get("force", False))
         switch = self.controller.get_switch_by_dpid(dpid)
+        log.info(
+            f"Send FlowMod from KytosEvent dpid: {dpid}, command: {command}, "
+            f"force: {force}, flows_dict: {flow_dict}"
+        )
         try:
             self._install_flows(command, flow_dict, [switch], reraise_conn=not force)
         except InvalidCommandError as error:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -305,8 +305,9 @@ class TestMain(TestCase):
         mock_send_barrier_request.assert_called()
         self.napp.flow_controller.delete_flows_by_ids.assert_not_called()
 
+    @patch("napps.kytos.flow_manager.main.log")
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
-    def test_event_add_flow(self, mock_install_flows):
+    def test_event_add_flow(self, mock_install_flows, mock_log):
         """Test method for installing flows on the switches through events."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
@@ -320,9 +321,11 @@ class TestMain(TestCase):
         mock_install_flows.assert_called_with(
             "add", mock_flow_dict, [switch], reraise_conn=True
         )
+        mock_log.info.assert_called()
 
+    @patch("napps.kytos.flow_manager.main.log")
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
-    def test_event_flows_install_delete(self, mock_install_flows):
+    def test_event_flows_install_delete(self, mock_install_flows, mock_log):
         """Test method for removing flows on the switches through events."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
@@ -336,6 +339,7 @@ class TestMain(TestCase):
         mock_install_flows.assert_called_with(
             "delete", mock_flow_dict, [switch], reraise_conn=True
         )
+        mock_log.info.assert_called()
 
     @patch("napps.kytos.flow_manager.main.log")
     @patch("napps.kytos.flow_manager.main.Main._install_flows")


### PR DESCRIPTION
Fixes #86 

- Added log.info entry for kytos.flow_manager.flows.(install|delete) handler for troubleshooting, same as flow_manaer has for the `/flows` endpoint

For more info, checkout [this thread](https://github.com/kytos-ng/flow_manager/pull/82#discussion_r886101436) that @italovalcy and I were exchanging ideas about this log. 

## Example when this handle is used now

```
kytos $> 2022-05-31 18:55:03,069 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_3) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: False,
flows_dict: {'flows': [{'cookie': 12254757024401928266, 'cookie_mask': 18446744073709551615}]}
2022-05-31 18:55:03,070 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_7) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:03, command: delete, force: False, flows_dict: {'flows': [{'cookie': 12254757024401928266, 'cookie_mask': 18446744073709551615}]}
2022-05-31 18:55:03,129 - INFO [kytos.napps.kytos/mef_eline] (Thread-28) EVC(11a495d033304a, epl) was deployed.
2022-05-31 18:55:03,130 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_4) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:03, command: add, force: False, flows_dict:
{'flows': [{'match': {'in_port': 1}, 'cookie': 12254757024401928266, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2775}, {'action_type': 'output', 'port': 2}], 'priority': 100}, {'match': {'in_port': 2, 'dl_vlan': 2775}, 'cookie': 12254757024401928266, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'priority': 100}]}
2022-05-31 18:55:03,133 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_9) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: add, force: False, flows_dict:
{'flows': [{'match': {'in_port': 2, 'dl_vlan': 2425}, 'cookie': 12254757024401928266, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 2775}, {'action_type': 'output', 'port': 3}], '
priority': 100}, {'match': {'in_port': 3, 'dl_vlan': 2775}, 'cookie': 12254757024401928266, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 2425}, {'action_type': 'output', 'port':2}], 'priority': 100}]}
2022-05-31 18:55:03,182 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_6) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict:
{'flows': [{'match': {'in_port': 1}, 'cookie': 12254757024401928266, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2425}, {'action_type': 'output', 'port': 2}], 'priority': 100}, {'match': {'in_port': 2, 'dl_vlan': 2425}, 'cookie': 12254757024401928266, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'priority': 100}]}
kytos $>
```