### PR TITLE
[Fix] OFPT_BARRIER_REQUEST should be sent in bulk once per flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 - Refactored `flows` upsert and delete operations to use `bulk_write` instead for higher performance based on the expected workload
 - Endpoint /flow_manager/v2/flows/ writes first to the database now to optimize consistency for bulk operations.
 - Set KytosEvent priority for OFPT_FLOW_MOD and OFPT_BARRIER_REQUEST
+- OFPT_BARRIER_REQUEST is sent in bulk once per flows
 
 Deprecated
 ==========

--- a/main.py
+++ b/main.py
@@ -611,10 +611,10 @@ class Main(KytosNApp):
     ):
         """Send FlowMod (and BarrierRequest) given a list of flow_dicts to switches."""
         for switch in switches:
-            for flow_mod, flow in zip(flow_mods, flows):
+            for i, (flow_mod, flow) in enumerate(zip(flow_mods, flows)):
                 try:
                     self._send_flow_mod(switch, flow_mod)
-                    if send_barrier:
+                    if send_barrier and i == len(flow_mods) - 1:
                         self._send_barrier_request(switch, flow_mod)
                 except SwitchNotConnectedError:
                     if reraise_conn:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -260,12 +260,13 @@ class TestMain(TestCase):
         serializer.from_dict.return_value = flow
         mock_flow_factory.return_value = serializer
 
-        flows_dict = {"flows": [MagicMock()]}
+        flows_dict = {"flows": [MagicMock(), MagicMock()]}
         switches = [self.switch_01]
         self.napp._install_flows("add", flows_dict, switches)
 
         mock_send_flow_mod.assert_called_with(self.switch_01, flow_mod)
-        mock_send_barrier_request.assert_called()
+        assert mock_send_flow_mod.call_count == len(flows_dict["flows"])
+        assert mock_send_barrier_request.call_count == 1
         mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid, flow, "add")
         mock_send_napp_event.assert_called_with(self.switch_01, flow, "pending")
         self.napp.flow_controller.upsert_flows.assert_called()


### PR DESCRIPTION
Fixes #93 

## Release Notes

- OFPT_BARRIER_REQUEST is sent in bulk once per flows

As long as mef_eline also start grouping the requests per switch it could benefit more from this change too. @italovalcy if there's anything else to be covered let me know.

No changes in the retries and send barrier when handling `kytos/core.openflow.connection.error` though. 

## Benchmarks and results

This stress test sends 60 requests / sec with 5 flows on each request. 

- Using this branch, `306.251ms` 95 percentile and `504.928ms` max latency. 

![2022-06-23-164825_1666x605_scrot](https://user-images.githubusercontent.com/1010796/175388364-bf8fca7b-2b41-4ec9-bcfc-79bbc64d1d4a.png)


```
❯ jq -ncM '{method: "POST", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_port": 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 101 }, "actions": [ { "action_type": "output", "por
t": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 102 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 103 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 104 }, "actions": [ { "action_type": "output", "port": 1 } ] }] } | @base64, header: {"Content-Type": ["application/json"]}}' | vegeta attack -format=json -rate 60/1s -duration=10s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         600, 60.11, 59.06
Duration      [total, attack, wait]             10.16s, 9.982s, 177.195ms
Latencies     [min, mean, 50, 90, 95, 99, max]  14.836ms, 120.665ms, 98.238ms, 224.16ms, 306.251ms, 428.558ms, 504.928ms
Bytes In      [total, mean]                     22200, 37.00
Bytes Out     [total, mean]                     308400, 514.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:600
Error Set:
```

- Using the `master` branch, `6.467s` 95 percentile and `8.44s` max latency. 

![2022-06-23-165049_1676x648_scrot](https://user-images.githubusercontent.com/1010796/175388453-a36a514a-62d0-4957-afad-9a1b39ee5a60.png)


```
❯ jq -ncM '{method: "POST", url: "http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01", body: { "force": true, "flows": [ { "priority": 10, "match": { "in_port": 1, "dl_vlan": 100 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 101 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 102 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 103 }, "actions": [ { "action_type": "output", "port": 1 } ] }, { "priority": 10, "match": { "in_port": 1, "dl_vlan": 104 }, "actions": [ { "action_type": "output", "port": 1 } ] }] } | @base64, header: {"Content-Type": ["application/json"]}}' | vegeta attack -format=json -rate 60/1s -duration=10s | tee results.bin | vegeta report
Requests      [total, rate, throughput]         600, 60.10, 43.39
Duration      [total, attack, wait]             13.828s, 9.983s, 3.844s
Latencies     [min, mean, 50, 90, 95, 99, max]  75.036ms, 3.104s, 3.197s, 5.819s, 6.467s, 7.923s, 8.44s
Bytes In      [total, mean]                     22200, 37.00
Bytes Out     [total, mean]                     308400, 514.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      202:600
Error Set:
```