### PR TITLE
[Fix] Added support for unloaded switch version falling back to Flow04

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from napps.kytos.flow_manager.match import match_flow
 from napps.kytos.of_core.flow import FlowFactory
 from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_core.settings import STATS_INTERVAL
+from napps.kytos.of_core.v0x04.flow import Flow as Flow04
 from pyof.v0x01.asynchronous.error_msg import BadActionCode
 from pyof.v0x01.common.phy_port import PortConfig
 from pyof.v0x04.common.header import Type
@@ -581,7 +582,7 @@ class Main(KytosNApp):
         """
         flow_mods, flows, flow_dicts = [], [], []
         for switch in switches:
-            serializer = FlowFactory.get_class(switch)
+            serializer = FlowFactory.get_class(switch, Flow04)
             flows_list = flows_dict.get("flows", [])
             for flow_dict in flows_list:
                 flow = serializer.from_dict(flow_dict, switch)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 """kytos/flow_manager NApp installs, lists and deletes switch flows."""
 
-# pylint: disable=relative-beyond-top-level
+# pylint: disable=relative-beyond-top-level,too-many-function-args
 import time
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,7 @@ from napps.kytos.flow_manager.exceptions import (
     InvalidCommandError,
     SwitchNotConnectedError,
 )
+from napps.kytos.of_core.v0x04.flow import Flow as Flow04
 from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
 
 from kytos.core.helpers import now
@@ -230,6 +231,7 @@ class TestMain(TestCase):
             [match_id],
             flow_dicts,
         )
+        mock_flow_factory.assert_called_with(self.switch_01, Flow04)
 
     def test_get_all_switches_enabled(self):
         """Test _get_all_switches_enabled method."""


### PR DESCRIPTION
Fixes #95 

Added support for unloaded switch version falling back to Flow04 on FlowFactory.get_class [that is available on this PR](https://github.com/kytos-ng/of_core/pull/74). It fallsback to Flow04 since this is the major version we plan to have support for the foreseeable future, we could also try to restore `ofp_version` but it's not worth it considering it would need extra changes and considering the direction with gRPC and P4 that our team will support. 

#### Example

If you repeat the original corner case it doesn't crash anymore and it returns 424 as expected or 202 if the `force` option is used:

```
❯ echo '{"force": false, "flows": [ { "match": { "in_port": 1 }, "actions": [ { "action_type": "output", "port": 2 } ] } ] }' | http POST http://localhost:8181/api/kytos/flow_manager/v2/
flows/00:00:00:00:00:00:00:01
HTTP/1.0 424 FAILED DEPENDENCY
Access-Control-Allow-Origin: *
Content-Length: 103
Content-Type: application/json
Date: Wed, 27 Jul 2022 21:46:03 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{
    "code": 424,
    "description": "switch 00:00:00:00:00:00:00:01 isn't connected",
    "name": "Failed Dependency"
}

❯ echo '{"force": true, "flows": [ { "match": { "in_port": 1 }, "actions": [ { "action_type": "output", "port": 2 } ] } ] }' | http POST http://localhost:8181/api/kytos/flow_manager/v2/f
lows/00:00:00:00:00:00:00:01
HTTP/1.0 202 ACCEPTED
Access-Control-Allow-Origin: *
Content-Length: 37
Content-Type: application/json
Date: Wed, 27 Jul 2022 21:46:20 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{
    "response": "FlowMod Messages Sent"
}
```

and then, once the switch is connected again, consistency check will install the flow missing flow accordingly:

```
2022-07-27 18:46:49,202 - INFO [kytos.napps.kytos/of_core] [main.py:178:handle_features_reply] (thread_pool_sb_0) Connection ('127.0.0.1', 39772), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2022-07-27 18:46:49,221 - INFO [kytos.napps.kytos/flow_manager] [main.py:537:_send_flow_mods_from_request] (Thread-23) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type':'output', 'port': 4294967293}]}]}
2022-07-27 18:46:49,227 - INFO [kytos.napps.kytos/of_core] [main.py:178:handle_features_reply] (thread_pool_sb_3) Connection ('127.0.0.1', 39784), Switch 00:00:00:00:00:00:00:03: OPENFLOW HANDSHAKE COMPLETE
2022-07-27 18:46:49,235 - INFO [kytos.napps.kytos/of_core] [main.py:178:handle_features_reply] (thread_pool_sb_2) Connection ('127.0.0.1', 39798), Switch 00:00:00:00:00:00:00:02: OPENFLOW HANDSHAKE COMPLETE
2022-07-27 18:46:49,251 - INFO [kytos.napps.kytos/flow_manager] [main.py:537:_send_flow_mods_from_request] (Thread-26) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677059, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-07-27 18:46:49,251 - INFO [kytos.napps.kytos/flow_manager] [main.py:537:_send_flow_mods_from_request] (Thread-27) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677058, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-07-27 18:46:50,266 - INFO [kytos.napps.kytos/flow_manager] [main.py:355:check_missing_flows] (thread_pool_sb_1) Consistency check: missing flow on switch 00:00:00:00:00:00:00:01.
2022-07-27 18:46:50,276 - INFO [kytos.napps.kytos/flow_manager] [main.py:359:check_missing_flows] (thread_pool_sb_1) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be installed. Flow: {'flows': [{'cookie': 0, 'match': {'in_port': 1}, 'actions': [{'action_type': 'output', 'port': 2}], 'table_id': 0, 'priority': 32768, 'idle_timeout': 0, 'hard_timeout': 0}]}
kytos $>
```