### PR TITLE
[Fix] Consistency check to avoid deleting certain recent changes

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -127,10 +127,10 @@ class FlowController:
         """Delete flow by id."""
         return self.db.flows.delete_one({"flow_id": flow_id}).deleted_count
 
-    def get_flows_lte_inserted_at(self, dpid: str, dt: datetime) -> Iterator[dict]:
-        """Get flows less than or equal inserted_at."""
+    def get_flows_lte_updated_at(self, dpid: str, dt: datetime) -> Iterator[dict]:
+        """Get flows less than or equal updated_at."""
         for flow in self.db.flows.find(
-            {"switch": dpid, "inserted_at": {"$lte": dt}}
+            {"switch": dpid, "updated_at": {"$lte": dt}}
         ).sort("inserted_at", pymongo.ASCENDING):
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
             yield flow

--- a/main.py
+++ b/main.py
@@ -344,12 +344,12 @@ class Main(KytosNApp):
         """Build switch.flows indexed by id."""
         return {flow.id: flow for flow in switch.flows if filter_flow(flow)}
 
-    def check_missing_flows(self, switch):
+    def check_missing_flows(self, switch, stats_interval=STATS_INTERVAL):
         """Check missing flows on a switch and install them."""
         dpid = switch.dpid
         flows = self.switch_flows_by_id(switch, self.is_not_ignored_flow)
         for flow in self.flow_controller.get_flows_lte_updated_at(
-            switch.id, datetime.utcnow() - timedelta(seconds=STATS_INTERVAL)
+            switch.id, datetime.utcnow() - timedelta(seconds=stats_interval)
         ):
             if flow["flow_id"] not in flows:
                 log.info(f"Consistency check: missing flow on switch {dpid}.")
@@ -365,7 +365,7 @@ class Main(KytosNApp):
                         f"Flow: {flow}"
                     )
 
-    def check_alien_flows(self, switch):
+    def check_alien_flows(self, switch, stats_interval=STATS_INTERVAL):
         """Check alien flows on a switch and delete them."""
         dpid = switch.dpid
         stored_by_flow_id = {}
@@ -379,7 +379,7 @@ class Main(KytosNApp):
             if flow_id not in stored_by_flow_id:
 
                 # Skip if it's been updated within the last consistency check
-                delta = datetime.utcnow() - timedelta(seconds=STATS_INTERVAL)
+                delta = datetime.utcnow() - timedelta(seconds=stats_interval)
                 if (
                     flow.match_id in stored_by_match
                     and stored_by_match[flow.match_id]["updated_at"] >= delta

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -93,14 +93,14 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         args = self.flow_controller.db.flows.delete_one.call_args[0]
         assert args[0] == {"flow_id": self.flow_id}
 
-    def test_get_flows_lte_inserted_at(self) -> None:
-        """Test get_flows_lte_inserted_at."""
+    def test_get_flows_lte_updated_at(self) -> None:
+        """Test get_flows_lte_updated_at."""
         dt = datetime.utcnow()
-        flows = list(self.flow_controller.get_flows_lte_inserted_at(self.dpid, dt))
+        flows = list(self.flow_controller.get_flows_lte_updated_at(self.dpid, dt))
         assert not flows
         args = self.flow_controller.db.flows.find.call_args[0]
         assert args[0] == {
-            "inserted_at": {"$lte": dt},
+            "updated_at": {"$lte": dt},
             "switch": self.dpid,
         }
         args = self.flow_controller.db.flows.find(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -495,7 +495,7 @@ class TestMain(TestCase):
         self.napp.flow_controller.get_flows_lte_updated_at.return_value = [
             {"flow_id": "2", "flow": {}}
         ]
-        self.napp.check_missing_flows(switch)
+        self.napp.check_missing_flows(switch, stats_interval=60)
         mock_install_flows.assert_called()
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
@@ -516,7 +516,7 @@ class TestMain(TestCase):
                 "updated_at": datetime.utcnow() - timedelta(seconds=60),
             }
         ]
-        self.napp.check_alien_flows(switch)
+        self.napp.check_alien_flows(switch, stats_interval=60)
         mock_install_flows.assert_called()
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
@@ -539,7 +539,7 @@ class TestMain(TestCase):
                 "updated_at": datetime.utcnow() - timedelta(seconds=5),
             }
         ]
-        self.napp.check_alien_flows(switch)
+        self.napp.check_alien_flows(switch, stats_interval=60)
         mock_install_flows.assert_not_called()
 
     def test_consistency_cookie_ignored_range(self):


### PR DESCRIPTION
Fixes #100, thanks for reporting and catching this @italovalcy

- Replaced `get_flows_lte_inserted_at` with `get_flows_lte_updated_at`
- Fixed missing flows to consider `updated_at` instead of `inserted_at`
- Fixed alien flows to skip if it's comparing with a recent updated flow

I didn't update the changelog since this bug has been introduced in this unreleased/development version. 

### Example

Using a similar case that Italo has provided:

- If you install an overlapping flow at the right time when the consistency check is checking for alien flows it'll skip it (I added also a temporary log to facilitate understanding `skipping alien`):

```
2022-08-05 14:50:21,947 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 has started
kytos $> 2022-08-05 14:50:25,537 - INFO [kytos.napps.kytos/flow_manager] (Thread-92) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'force': False, 'flows': [{'priority': 101, 'match': {'in_port': 1, 'dl_vlan': 104}, 'actions': [{'action_type': 'output', 'port': 3}]}]}
2022-08-05 14:50:31,961 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_2) skipping alien {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vlan': 104}, 'priority': 101, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 0, 'id': 'c5b08549dc26944cdd71dcb6b1c5b6a9', 'stats':{'byte_count': 0, 'duration_sec': 89, 'duration_nsec': 64
5000000, 'packet_count': 0}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 5,'action_type': 'output'}]}]}
2022-08-05 14:50:31,967 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 is done
2022-08-05 14:50:36,478 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 has started
```

- In the next iteration of consistency check if doesn't do anything since the flow stats is updated:

```
kytos $> 2022-08-05 14:50:46,492 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 is done
2022-08-05 14:50:56,507 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 has started
```

- After that, I simulated a legitimate alien flow and it deleted as expected:

```
kytos $> 2022-08-05 14:51:16,512 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) check_consistency on switch 00:00:00:00:00:00:00:01 has started
2022-08-05 14:51:26,528 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) Consistency check: alien flow on switch 00:00:00:00:00:00:00:01
2022-08-05 14:51:26,531 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be deleted. Flow: {'flows': [{'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 1000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 4097, 'id': '13bc34e4a7a3d61cd0d0ebb7c49991ff', 'stats': {'byte_count': 0, 'duration_sec': 1, 'duration_nsec': 890000000, 'packet_count': 0}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}]}
2022-08-05 14:51:26,541 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) check_consistency on switch 00:00:00:00:00:00:00:01 is done
```

- After that, I also simulated positive missing flows:

```
kytos $> 2022-08-05 14:51:36,505 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) check_consistency on switch 00:00:00:00:00:00:00:01 has started
2022-08-05 14:51:46,519 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) Consistency check: missing flow on switch 00:00:00:00:00:00:00:01.
2022-08-05 14:51:46,521 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be installed. Flow: {'flows': [{'cookie': 1232184
8580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}], 'table_id': 0, 'priority': 1000, 'idle_timeout': 0, 'hard_timeout': 0}]}
2022-08-05 14:51:46,521 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) Consistency check: missing flow on switch 00:00:00:00:00:00:00:01.
2022-08-05 14:51:46,522 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be installed. Flow: {'flows': [{'cookie': 0, 'match': {'in_port': 1, 'dl_vlan': 104}, 'actions': [{'action_type': 'output', 'port': 3}], 'table_id': 0, 'priority': 101, 'idle_timeout': 0, 'hard_timeout': 0}]}
2022-08-05 14:51:46,522 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) check_consistency on switch 00:00:00:00:00:00:00:01 is done
kytos $>
```

@italovalcy could you try out this branch with the original problem to also have a double confirmation, thanks? 