### PR TITLE
[Fix] Consistency check fixes part 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,13 @@ file.
 ********************************
 Added
 =====
-- MongoDB integration with pymongo
-- Flows are stored now on MongoDB flows collections
-- Consistency checks executions are stored on MongoDB flow_checks collection
+- MongoDB integration with ``pymongo``
+- Added and soft deleted flows are stored now on MongoDB ``flows`` collections.
+- Consistency checks executions are stored on MongoDB ``flow_checks`` collection
 - FlowController and DB models
 - ``scripts/storehouse_to_mongo.py`` script to migrate data from storehouse to MongoDB
 - Added log.info entry for kytos.flow_manager.flows.(install|delete) handler for troubleshooting
+- ``CONSISTENCY_MIN_VERDICT_INTERVAL``, granular control for the minimum expected interval that consistency check should wait before detecting inconsistencies
 
 Changed
 =======
@@ -22,6 +23,7 @@ Changed
 - Endpoint /flow_manager/v2/flows/ writes first to the database now to optimize consistency for bulk operations.
 - Set KytosEvent priority for OFPT_FLOW_MOD and OFPT_BARRIER_REQUEST
 - OFPT_BARRIER_REQUEST is sent in bulk once per flows
+- Consistency check will act slower than ``FLOW_STATS`` to enhance consistency
 
 Deprecated
 ==========

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Events
 Subscribed
 ----------
 
-- ``.*.connection.lost``
+- ``kytos/of_core.handshake.completed``
 - ``kytos.flow_manager.flows.(install|delete)``
 - ``kytos/of_core.flow_stats.received``
 - ``kytos/of_core.v0x0[14].messages.in.ofpt_flow_removed``

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -101,10 +101,6 @@ class FlowController:
         else:
             update_expr.update({"$set": {"updated_at": datetime.utcnow()}})
 
-    def update_flow_state(self, flow_id: str, state: str) -> Optional[dict]:
-        """Update flow state."""
-        return self._update_flow(flow_id, {"$set": {"state": state}})
-
     def _update_flow(self, flow_id: str, update_expr: dict) -> Optional[dict]:
         """Try to find one flow and update it given an update expression."""
         self._set_updated_at(update_expr)

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -164,6 +164,12 @@ class FlowController:
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
             yield flow
 
+    def get_flows_by_ne_state(self, dpid: str, state: str) -> Iterator[dict]:
+        """Get flows by not equal state."""
+        for flow in self.db.flows.find({"switch": dpid, "state": {"$ne": state}}):
+            flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
+            yield flow
+
     def upsert_flow_check(self, dpid: str, state="active") -> Optional[dict]:
         """Update or insert flow check."""
         utc_now = datetime.utcnow()

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -164,12 +164,6 @@ class FlowController:
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
             yield flow
 
-    def get_flows_by_ne_state(self, dpid: str, state: str) -> Iterator[dict]:
-        """Get flows by not equal state."""
-        for flow in self.db.flows.find({"switch": dpid, "state": {"$ne": state}}):
-            flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
-            yield flow
-
     def upsert_flow_check(self, dpid: str, state="active") -> Optional[dict]:
         """Update or insert flow check."""
         utc_now = datetime.utcnow()

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -52,6 +52,7 @@ class FlowController:
                     ("flow.cookie", pymongo.ASCENDING),
                     ("state", pymongo.ASCENDING),
                     ("inserted_at", pymongo.ASCENDING),
+                    ("updated_at", pymongo.ASCENDING),
                 ],
                 {},
             ),
@@ -119,10 +120,6 @@ class FlowController:
             {"flow_id": {"$in": flow_ids}}, {"$set": {"state": state}}
         ).modified_count
 
-    def delete_flows_by_ids(self, flow_ids: List[str]) -> int:
-        """Delete flows by ids."""
-        return self.db.flows.delete_many({"flow_id": {"$in": flow_ids}}).deleted_count
-
     def delete_flow_by_id(self, flow_id: str) -> int:
         """Delete flow by id."""
         return self.db.flows.delete_one({"flow_id": flow_id}).deleted_count
@@ -130,22 +127,14 @@ class FlowController:
     def get_flows_lte_updated_at(self, dpid: str, dt: datetime) -> Iterator[dict]:
         """Get flows less than or equal updated_at."""
         for flow in self.db.flows.find(
-            {"switch": dpid, "updated_at": {"$lte": dt}}
+            {"switch": dpid, "updated_at": {"$lte": dt}, "state": {"$ne": "deleted"}}
         ).sort("inserted_at", pymongo.ASCENDING):
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
             yield flow
 
     def get_flows(self, dpid: str) -> Iterator[dict]:
         """Get flows."""
-        for flow in self.db.flows.find({"switch": dpid}):
-            flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
-            yield flow
-
-    def get_flows_by_cookie(self, dpid: str, cookie: int) -> Iterator[dict]:
-        """Get flows by cookie."""
-        for flow in self.db.flows.find(
-            {"switch": dpid, "flow.cookie": Decimal128(Decimal(cookie))}
-        ):
+        for flow in self.db.flows.find({"switch": dpid, "state": {"$ne": "deleted"}}):
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
             yield flow
 
@@ -157,6 +146,7 @@ class FlowController:
                 {
                     "$match": {
                         "switch": {"$in": dpids},
+                        "state": {"$ne": "deleted"},
                         "flow.cookie": {
                             "$in": [Decimal128(Decimal(cookie)) for cookie in cookies]
                         },
@@ -191,13 +181,6 @@ class FlowController:
         )
         return updated
 
-    def get_flow_check_gte_updated_at(
-        self,
-        dpid: str,
-        dt: datetime,
-        state="active",
-    ) -> Optional[dict]:
-        """Get flow check greater than or equal updated_at."""
-        return self.db.flow_checks.find_one(
-            {"_id": dpid, "state": state, "updated_at": {"$gte": dt}}
-        )
+    def get_flow_check(self, dpid: str, state="active") -> Optional[dict]:
+        """Get flow check."""
+        return self.db.flow_checks.find_one({"_id": dpid, "state": state})

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -112,8 +112,10 @@ class FlowController:
 
     def update_flows_state(self, flow_ids: List[str], state: str) -> int:
         """Bulk update flows state."""
+        update_expr = {"$set": {"state": state}}
+        self._set_updated_at(update_expr)
         return self.db.flows.update_many(
-            {"flow_id": {"$in": flow_ids}}, {"$set": {"state": state}}
+            {"flow_id": {"$in": flow_ids}}, update_expr
         ).modified_count
 
     def delete_flow_by_id(self, flow_id: str) -> int:

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -17,6 +17,7 @@ class FlowEntryState(Enum):
 
     PENDING = "pending"  # initial state, it has been stored, but not confirmed yet
     INSTALLED = "installed"  # final state, when the installtion has been confirmed
+    DELETED = "deleted"  # final state when the flow gets soft deleted
 
 
 class DocumentBaseModel(BaseModel):

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ from kytos.core.helpers import listen_to, now
 
 from .barrier_request import new_barrier_request
 from .controllers import FlowController
+from .db.models import FlowEntryState
 from .exceptions import InvalidCommandError, SwitchNotConnectedError
 from .settings import (
     CONN_ERR_MAX_RETRIES,
@@ -47,7 +48,6 @@ from .utils import (
     get_min_wait_diff,
     is_ignored,
 )
-from .db.models import FlowEntryState
 
 
 class Main(KytosNApp):

--- a/main.py
+++ b/main.py
@@ -126,10 +126,10 @@ class Main(KytosNApp):
                 raise
         log.info(f"Flows resent to Switch {dpid}")
 
-    @listen_to(".*.connection.lost")
-    def on_connection_lost(self, event):
-        """On switch connection lost handler."""
-        switch = event.content["source"].switch
+    @listen_to("kytos/of_core.handshake.completed")
+    def on_handshake_completed(self, event):
+        """On switch connection handshake completed."""
+        switch = event.content["switch"]
         if not switch:
             return
         self.reset_flow_check(switch.id)

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from .settings import (
     CONN_ERR_MIN_WAIT,
     CONN_ERR_MULTIPLIER,
     CONSISTENCY_COOKIE_IGNORED_RANGE,
+    CONSISTENCY_MIN_VERDICT_INTERVAL,
     CONSISTENCY_TABLE_ID_IGNORED_RANGE,
     ENABLE_BARRIER_REQUEST,
     ENABLE_CONSISTENCY_CHECK,
@@ -47,13 +48,7 @@ from .utils import (
     get_min_wait_diff,
     is_ignored,
 )
-
-
-class FlowEntryState(Enum):
-    """Enum for stored Flow Entry states."""
-
-    PENDING = "pending"  # initial state, it has been stored, but not confirmed yet
-    INSTALLED = "installed"  # final state, when the installtion has been confirmed
+from .db.models import FlowEntryState
 
 
 class Main(KytosNApp):
@@ -74,6 +69,9 @@ class Main(KytosNApp):
             self.cookie_ignored_range = CONSISTENCY_COOKIE_IGNORED_RANGE
         if _valid_consistency_ignored(CONSISTENCY_TABLE_ID_IGNORED_RANGE):
             self.tab_id_ignored_range = CONSISTENCY_TABLE_ID_IGNORED_RANGE
+        self._consistency_verdict = max(
+            CONSISTENCY_MIN_VERDICT_INTERVAL, STATS_INTERVAL + STATS_INTERVAL // 2
+        )
 
         self.flow_controller = self.get_flow_controller()
         self.flow_controller.bootstrap_indexes()
@@ -85,7 +83,6 @@ class Main(KytosNApp):
         self._pending_barrier_max_size = FLOWS_DICT_MAX_SIZE
 
         self._flow_mods_sent_error = {}
-        self._flow_mods_sent_error_lock = Lock()
         self._flow_mods_retry_count = {}
         self._flow_mods_retry_count_lock = Lock()
         self.resent_flows = set()
@@ -180,35 +177,38 @@ class Main(KytosNApp):
         message = event.message
         xid = int(message.header.xid)
         with self._pending_barrier_lock:
-            flow_xid = self._pending_barrier_reply[switch.id].pop(xid, None)
-            if not flow_xid:
+            flow_xids = self._pending_barrier_reply[switch.id].pop(xid, None)
+            if not flow_xids:
                 log.error(
-                    f"Failed to pop barrier reply xid: {xid}, flow xid: {flow_xid}"
+                    f"Failed to pop barrier reply xid: {xid}, flow xids: {flow_xids}"
                 )
                 return
-        with self._flow_mods_sent_lock:
-            if flow_xid not in self._flow_mods_sent:
-                log.error(
-                    f"Flow xid: {flow_xid} not in flow mods sent. Inconsistent state"
-                )
-                return
-            flow, _ = self._flow_mods_sent[flow_xid]
 
+        flows = []
+        with self._flow_mods_sent_lock:
+            flows = [
+                self._flow_mods_sent[flow_xid][0]
+                for flow_xid in flow_xids
+                if flow_xid not in self._flow_mods_sent_error
+                and flow_xid in self._flow_mods_sent
+            ]
         """
         It should only publish installed flow if it the original FlowMod xid hasn't
         errored out. OFPT_ERROR messages could be received first if the barrier request
         hasn't been sent out or processed yet this can happen if the network latency
         is super low.
         """
-        with self._flow_mods_sent_error_lock:
-            error_kwargs = self._flow_mods_sent_error.get(flow_xid)
-        if not error_kwargs:
-            self._publish_installed_flow(switch, flow)
+        if flows:
+            self._publish_installed_flow(switch, flows)
 
-    def _publish_installed_flow(self, switch, flow):
+    def _publish_installed_flow(self, switch, flows):
         """Publish installed flow when it's confirmed."""
-        self._send_napp_event(switch, flow, "add")
-        self.flow_controller.update_flow_state(flow.id, FlowEntryState.INSTALLED.value)
+        for flow in flows:
+            self._send_napp_event(switch, flow, "add")
+            # TODO bulk update
+            self.flow_controller.update_flow_state(
+                flow.id, FlowEntryState.INSTALLED.value
+            )
 
     @listen_to("kytos/of_core.flow_stats.received")
     def on_flow_stats_publish_installed_flows(self, event):
@@ -315,21 +315,19 @@ class Main(KytosNApp):
         """Check consistency of stored and installed flows given a switch."""
         if not ENABLE_CONSISTENCY_CHECK or not switch.is_enabled():
             return
-        flow_check = self.flow_controller.get_flow_check_gte_updated_at(
-            switch.id, datetime.utcnow() - timedelta(seconds=STATS_INTERVAL / 2)
-        )
-        if flow_check:
-            log.info(
-                f"Skipping recent consistency check exec on switch {switch.id}, "
-                f"last checked at {flow_check['updated_at']}"
-            )
+
+        flow_check = self.flow_controller.get_flow_check(switch.id)
+        verdict_dt = datetime.utcnow() - timedelta(seconds=self._consistency_verdict)
+
+        # Skip, if the last relative run is within the verdict datetime
+        if flow_check and flow_check["updated_at"] >= verdict_dt:
             return
 
-        self.flow_controller.upsert_flow_check(switch.id)
         log.debug(f"check_consistency on switch {switch.id} has started")
         self.check_alien_flows(switch)
         self.check_missing_flows(switch)
         log.debug(f"check_consistency on switch {switch.id} is done")
+        self.flow_controller.upsert_flow_check(switch.id)
 
     def is_not_ignored_flow(self, flow) -> bool:
         """Is not ignored flow."""
@@ -344,12 +342,13 @@ class Main(KytosNApp):
         """Build switch.flows indexed by id."""
         return {flow.id: flow for flow in switch.flows if filter_flow(flow)}
 
-    def check_missing_flows(self, switch, stats_interval=STATS_INTERVAL):
+    def check_missing_flows(self, switch):
         """Check missing flows on a switch and install them."""
+        verdict_dt = datetime.utcnow() - timedelta(seconds=self._consistency_verdict)
         dpid = switch.dpid
         flows = self.switch_flows_by_id(switch, self.is_not_ignored_flow)
         for flow in self.flow_controller.get_flows_lte_updated_at(
-            switch.id, datetime.utcnow() - timedelta(seconds=stats_interval)
+            switch.id, verdict_dt
         ):
             if flow["flow_id"] not in flows:
                 log.info(f"Consistency check: missing flow on switch {dpid}.")
@@ -365,25 +364,42 @@ class Main(KytosNApp):
                         f"Flow: {flow}"
                     )
 
-    def check_alien_flows(self, switch, stats_interval=STATS_INTERVAL):
+    def check_alien_flows(self, switch):
         """Check alien flows on a switch and delete them."""
         dpid = switch.dpid
         stored_by_flow_id = {}
         stored_by_match = {}
+        deleted_by_flow_id = {}
+
         for flow in self.flow_controller.get_flows(switch.id):
             stored_by_flow_id[flow["flow_id"]] = flow
             stored_by_match[flow["id"]] = flow
 
+        deleted_by_flow_id = {
+            flow["flow_id"]: flow
+            for flow in self.flow_controller.get_flows_by_state(
+                switch.id, FlowEntryState.DELETED.value
+            )
+        }
+
+        verdict_dt = datetime.utcnow() - timedelta(seconds=self._consistency_verdict)
         flows = self.switch_flows_by_id(switch, self.is_not_ignored_flow)
         for flow_id, flow in flows.items():
             if flow_id not in stored_by_flow_id:
-
-                # Skip if it's been updated within the last consistency check
-                delta = datetime.utcnow() - timedelta(seconds=stats_interval)
                 if (
                     flow.match_id in stored_by_match
-                    and stored_by_match[flow.match_id]["updated_at"] >= delta
+                    and stored_by_match[flow.match_id]["updated_at"] >= verdict_dt
                 ):
+                    # TODO Remove log
+                    log.info("Skipping recent installed Flow {flow.as_dict()}")
+                    continue
+
+                if (
+                    flow.id in deleted_by_flow_id
+                    and deleted_by_flow_id[flow.id]["updated_at"] >= verdict_dt
+                ):
+                    # TODO Remove log
+                    log.info("Skipping recent deleted Flow {flow.as_dict()}")
                     continue
 
                 log.info(f"Consistency check: alien flow on switch {dpid}")
@@ -408,9 +424,9 @@ class Main(KytosNApp):
         This deletion tries to minimize DB round trips, it aggregates all
         included cookies grouped by dpids, and then at the runtime it performs
         a non strict match iterating over the flows if they haven't been deleted yet.
-        If flows are matched, they will be bulk deleted.
+        If flows are matched, they will be bulk updated as deleted
         """
-        flow_ids_to_delete = set()
+        deleted_flows = {}
         cookies = list(
             {
                 int(value.get("cookie", 0)) & int(value.get("cookie_mask", 0))
@@ -422,16 +438,19 @@ class Main(KytosNApp):
         ).items():
             for flow_dict in flow_dicts:
                 for stored_flow in stored_flows:
-                    if stored_flow["flow_id"] in flow_ids_to_delete:
+                    if stored_flow["id"] in deleted_flows:
                         continue
                     if match_flow(
                         flow_dict["flow"],
                         switches[dpid].connection.protocol.version,
                         stored_flow["flow"],
                     ):
-                        flow_ids_to_delete.add(stored_flow["flow_id"])
-        if flow_ids_to_delete:
-            self.flow_controller.delete_flows_by_ids(list(flow_ids_to_delete))
+                        stored_flow["state"] = FlowEntryState.DELETED.value
+                        deleted_flows[stored_flow["id"]] = stored_flow
+        if deleted_flows:
+            self.flow_controller.upsert_flows(
+                deleted_flows.keys(), deleted_flows.values()
+            )
 
     # pylint: disable=attribute-defined-outside-init
     @rest("v2/flows")
@@ -628,7 +647,7 @@ class Main(KytosNApp):
                 try:
                     self._send_flow_mod(switch, flow_mod)
                     if send_barrier and i == len(flow_mods) - 1:
-                        self._send_barrier_request(switch, flow_mod)
+                        self._send_barrier_request(switch, flow_mods)
                 except SwitchNotConnectedError:
                     if reraise_conn:
                         raise
@@ -647,23 +666,25 @@ class Main(KytosNApp):
             self._flow_mods_sent.popitem(last=False)
         self._flow_mods_sent[xid] = (flow, command)
 
-    def _add_barrier_request(self, dpid, barrier_xid, flow_xid):
+    def _add_barrier_request(self, dpid, barrier_xid, flow_mods):
         """Add a barrier request."""
         if len(self._pending_barrier_reply[dpid]) >= self._pending_barrier_max_size:
             self._pending_barrier_reply[dpid].popitem(last=False)
-        self._pending_barrier_reply[dpid][barrier_xid] = flow_xid
+        self._pending_barrier_reply[dpid][barrier_xid] = [
+            flow_mod.header.xid for flow_mod in flow_mods
+        ]
 
-    def _send_barrier_request(self, switch, flow_mod):
+    def _send_barrier_request(self, switch, flow_mods):
         event_name = "kytos/flow_manager.messages.out.ofpt_barrier_request"
         if not switch.is_connected():
             raise SwitchNotConnectedError(
-                f"switch {switch.id} isn't connected", flow_mod
+                f"switch {switch.id} isn't connected", flow_mods
             )
 
         barrier_request = new_barrier_request(switch.connection.protocol.version)
         barrier_xid = barrier_request.header.xid
         with self._pending_barrier_lock:
-            self._add_barrier_request(switch.id, barrier_xid, flow_mod.header.xid)
+            self._add_barrier_request(switch.id, barrier_xid, flow_mods)
 
         content = {"destination": switch.connection, "message": barrier_request}
         event = KytosEvent(
@@ -727,8 +748,7 @@ class Main(KytosNApp):
             "error_command": error_command,
             "error_exception": event.content.get("exception"),
         }
-        with self._flow_mods_sent_error_lock:
-            self._flow_mods_sent_error[int(event.message.header.xid)] = error_kwargs
+        self._flow_mods_sent_error[int(event.message.header.xid)] = error_kwargs
         self._send_napp_event(
             switch,
             flow,
@@ -787,8 +807,7 @@ class Main(KytosNApp):
                 "error_type": error_type,
                 "error_code": error_code,
             }
-            with self._flow_mods_sent_error_lock:
-                self._flow_mods_sent_error[int(event.message.header.xid)] = error_kwargs
+            self._flow_mods_sent_error[int(event.message.header.xid)] = error_kwargs
             log.warning(
                 f"Deleting flow: {flow.as_dict()}, xid: {xid}, cookie: {flow.cookie}, "
                 f"error: {error_kwargs}"

--- a/main.py
+++ b/main.py
@@ -218,18 +218,18 @@ class Main(KytosNApp):
 
     def publish_installed_flows(self, switch):
         """Publish installed flows when they're confirmed."""
-        stored_flows = list(
-            self.flow_controller.get_flows_by_ne_state(
-                switch.id, FlowEntryState.INSTALLED.value
+        pending_flows = list(
+            self.flow_controller.get_flows_by_state(
+                switch.id, FlowEntryState.PENDING.value
             )
         )
-        if not stored_flows:
+        if not pending_flows:
             return
 
         installed_flows = self.switch_flows_by_id(switch, self.is_not_ignored_flow)
 
         flow_ids_to_update = []
-        for flow in stored_flows:
+        for flow in pending_flows:
             _id = flow["_id"]
             if _id not in installed_flows:
                 continue

--- a/settings.py
+++ b/settings.py
@@ -15,7 +15,7 @@ CONN_ERR_MIN_WAIT = 1  # minimum wait between iterations in seconds
 CONN_ERR_MULTIPLIER = 2  # multiplier for the accumulated wait on each iteration
 
 # Minimum consistency check verdict interval for start to consider inconsistencies.
-CONSISTENCY_MIN_VERDICT_INTERVAL = 60*2
+CONSISTENCY_MIN_VERDICT_INTERVAL = 60 * 2
 """
 Consistency check is eventually consistent, so the minimum interval is recommended
 to be at least greater than FLOW_STATS and ideally it slightly greater than

--- a/settings.py
+++ b/settings.py
@@ -15,11 +15,9 @@ CONN_ERR_MIN_WAIT = 1  # minimum wait between iterations in seconds
 CONN_ERR_MULTIPLIER = 2  # multiplier for the accumulated wait on each iteration
 
 # Minimum consistency check verdict interval for start to consider inconsistencies.
-CONSISTENCY_MIN_VERDICT_INTERVAL = 60*2 + 60//2
+CONSISTENCY_MIN_VERDICT_INTERVAL = 60*2
 """
 Consistency check is eventually consistent, so the minimum interval is recommended
 to be at least greater than FLOW_STATS and ideally it slightly greater than
-whichever longest convergence network sequence of operations you have in your
-network, you don't want consistency check to try to keep running while the network is
-still convergning with lots of FlowMods.
+whichever longest network convergence FlowMods operations that your network has.
 """

--- a/settings.py
+++ b/settings.py
@@ -13,3 +13,13 @@ CONSISTENCY_TABLE_ID_IGNORED_RANGE = []
 CONN_ERR_MAX_RETRIES = 3
 CONN_ERR_MIN_WAIT = 1  # minimum wait between iterations in seconds
 CONN_ERR_MULTIPLIER = 2  # multiplier for the accumulated wait on each iteration
+
+# Minimum consistency check verdict interval for start to consider inconsistencies.
+CONSISTENCY_MIN_VERDICT_INTERVAL = 60*2 + 60//2
+"""
+Consistency check is eventually consistent, so the minimum interval is recommended
+to be at least greater than FLOW_STATS and ideally it slightly greater than
+whichever longest convergence network sequence of operations you have in your
+network, you don't want consistency check to try to keep running while the network is
+still convergning with lots of FlowMods.
+"""

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -103,8 +103,19 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         args = self.flow_controller.db.flows.find.call_args[0]
         assert args[0] == {"switch": self.dpid, "state": {"$ne": "deleted"}}
 
+    def test_get_flows_by_cookies(self) -> None:
+        """Test get_flows_by_cookies."""
+        cookies = [0]
+        assert not list(self.flow_controller.get_flows_by_cookies([self.dpid], cookies))
+        args = self.flow_controller.db.flows.aggregate.call_args[0]
+        assert args[0][0]["$match"] == {
+            "switch": {"$in": [self.dpid]},
+            "state": {"$ne": "deleted"},
+            "flow.cookie": {"$in": [Decimal128(Decimal(cookie)) for cookie in cookies]},
+        }
+
     def test_get_flows_by_state(self) -> None:
-        """Test get_flows_by_cookie."""
+        """Test get_flows_by_state."""
         state = "installed"
         assert not list(self.flow_controller.get_flows_by_state(self.dpid, state))
         args = self.flow_controller.db.flows.find.call_args[0]

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -121,6 +121,13 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         args = self.flow_controller.db.flows.find.call_args[0]
         assert args[0] == {"switch": self.dpid, "state": "installed"}
 
+    def test_get_flows_by_ne_state(self) -> None:
+        """Test get_flows_by_ne_state."""
+        state = "installed"
+        assert not list(self.flow_controller.get_flows_by_ne_state(self.dpid, state))
+        args = self.flow_controller.db.flows.find.call_args[0]
+        assert args[0] == {"switch": self.dpid, "state": {"$ne": state}}
+
     def test_upsert_flow_check(self) -> None:
         """Test upsert_flow_check."""
         assert self.flow_controller.upsert_flow_check(self.dpid, "active")

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -68,13 +68,6 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         args = self.flow_controller.db.flows.bulk_write.call_args[0]
         assert len(args[0]) == len(flow_dicts)
 
-    def test_update_flow_state(self) -> None:
-        """Test update_flow_state."""
-        assert self.flow_controller.update_flow_state(self.flow_id, "installed")
-        arg1, arg2 = self.flow_controller.db.flows.find_one_and_update.call_args[0]
-        assert arg1 == {"flow_id": self.flow_id}
-        assert arg2["$set"]["state"] == "installed"
-
     def test_update_flows_state(self) -> None:
         """Test update_flows_state."""
         assert self.flow_controller.update_flows_state([self.flow_id], "installed")

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -121,13 +121,6 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         args = self.flow_controller.db.flows.find.call_args[0]
         assert args[0] == {"switch": self.dpid, "state": "installed"}
 
-    def test_get_flows_by_ne_state(self) -> None:
-        """Test get_flows_by_ne_state."""
-        state = "installed"
-        assert not list(self.flow_controller.get_flows_by_ne_state(self.dpid, state))
-        args = self.flow_controller.db.flows.find.call_args[0]
-        assert args[0] == {"switch": self.dpid, "state": {"$ne": state}}
-
     def test_upsert_flow_check(self) -> None:
         """Test upsert_flow_check."""
         assert self.flow_controller.upsert_flow_check(self.dpid, "active")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -776,7 +776,7 @@ class TestMain(TestCase):
         )
         flows = [flow1, flow2]
         switch.flows = flows
-        self.napp.flow_controller.get_flows_by_state.return_value = flows
+        self.napp.flow_controller.get_flows_by_ne_state.return_value = flows
         self.napp.publish_installed_flows(switch)
         assert mock_send_napp_event.call_count == len(flows)
         assert self.napp.flow_controller.update_flows_state.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -776,7 +776,7 @@ class TestMain(TestCase):
         )
         flows = [flow1, flow2]
         switch.flows = flows
-        self.napp.flow_controller.get_flows_by_ne_state.return_value = flows
+        self.napp.flow_controller.get_flows_by_state.return_value = flows
         self.napp.publish_installed_flows(switch)
         assert mock_send_napp_event.call_count == len(flows)
         assert self.napp.flow_controller.update_flows_state.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -660,13 +660,13 @@ class TestMain(TestCase):
         }
         self.napp.delete_matched_flows([flow1_dict], {switch.id: switch})
 
-        self.napp.flow_controller.upsert_flows.call_count == 1
+        assert self.napp.flow_controller.upsert_flows.call_count == 1
         call_args = self.napp.flow_controller.upsert_flows.call_args
         assert list(call_args[0][0]) == [flow1.match_id]
 
         # second arg should be the same dict values, except with state deleted
         expected = dict(flow1_dict)
-        expected["state"] == "deleted"
+        assert expected["state"] == "deleted"
         assert list(call_args[0][1])[0] == expected
 
     def test_add_barrier_request(self):
@@ -743,8 +743,7 @@ class TestMain(TestCase):
         event.message.header.xid = barrier_xid
         assert barrier_xid
         assert (
-            self.napp._pending_barrier_reply[switch.id][barrier_xid]
-            == flow_mods_xids
+            self.napp._pending_barrier_reply[switch.id][barrier_xid] == flow_mods_xids
         )
         event.source.switch = switch
 


### PR DESCRIPTION
This is on top of PR #101. It fixes the rest of the issues that have been surfaced, thanks @italovalcy for spotting newer ones on production-like environment. In summary (more details available on changelog if you need):

1 - **Added `CONSISTENCY_MIN_VERDICT_INTERVAL` on settings.py**:

Granular control for the minimum expected interval that consistency check should wait before detecting inconsistencies, after skipping recent updates or deletions. Each consistency execution will now keep track of when it was last run without assuming that it was run within `STATS_INTERVAL`, switches can get overloaded. Each execution is still driven by ``kytos/of_core.flow_stats.received`` though. This interval is recommended to be at lest greater than `FLOW_STATS` interval and ideally slightly greater than whichever longest network convergence FlowMods operations that your network has.

2 - **Replaced FlowMods hard deletions with soft deletions on flows**:

The existing `flows` collection has been modeled to have a `state` to keep track of the flow state, `installed` and `pending` up to this point, and now it's also been augmented for `deleted` to have a soft deletion instead of hard deletion. This allows the application to query for recent deleted flows (and skip them as needed). It's still not the same as archived flows that were discussed some time ago, since that needs more refinement and discussions. Notice that it'll only maintain the existing flow as it is, it won't keep track of history, having this can also help in prod, if flows are accidentely deleted, you can run a specific query and set again the `state` as `installed` and then consistency check will eventually reinstall them. If this is good enough for network operators we might not need archived flows for complete history. I was also going to add a partial index with TTL to auto delete entries, but for now it's probably not worth since it keeps running every 60 secs, in the future, we can introduce a similar task hard deleting flows after some time.

3 - **Fixed handling barrier request response to also operate in a list when confirming installed flows**

4 - **Included ``updated_at`` in the compound ``flows`` index based on how data is being queried**
