### PR TITLE
[Fix] Extracted resend_stored_flows for testability

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,7 +104,11 @@ class Main(KytosNApp):
         log.debug("flow-manager stopping")
 
     @listen_to("kytos/of_core.handshake.completed")
-    def resend_stored_flows(self, event):
+    def on_resend_stored_flows(self, event):
+        """Resend stored Flows."""
+        self.resend_stored_flows(event)
+
+    def resend_stored_flows(self, event) -> None:
         """Resend stored Flows."""
         # if consistency check is enabled, it should take care of this
         if ENABLE_CONSISTENCY_CHECK:


### PR DESCRIPTION
Fixes #106 

- Extracted resend_stored_flows for testability, it was using `listen_to`

In the future, we'll likely have better support on kytos core to have testability for this methods decorated with `listen_to`, in the meantime, following the existing pattern of extracting a new method at a expense of losing a few statements of unit code cov. 

I didn't add anything on changelog since this is just refactoring for testability. 