### PR TITLE
Adding endpoints for stored flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ file.
 Added
 =====
 
-- Added endpoint ``GET v2/stored_flows`` for listing flows from flows collection. Query parameter filter for state is supported.
+- Added endpoint ``GET v2/stored_flows`` for listing flows from flows collection. Query parameter filter for `state` and `dpid` is supported. A list of flows per switch is returned.
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ file.
 Added
 =====
 
-- Added endpoints ``GET v2/stored_flows`` and ``GET v2/stored_flows/<dpid>`` for listing flows from flows collection. Query parameter filter for state is supported.
+- Added endpoint ``GET v2/stored_flows`` for listing flows from flows collection. Query parameter filter for state is supported.
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ file.
 Added
 =====
 
+- Added endpoints ``GET v2/stored_flows`` and ``GET v2/stored_flows/<dpid>`` for listing flows from flows collection. Query parameter filter for state is supported.
+
 Fixed
 =====
 - Fixed handling ``OFPT_ERROR`` correctly when OF negotiation fails

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -4,6 +4,7 @@ import os
 from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal
+from operator import le
 from typing import Iterator, List, Optional
 
 import pymongo
@@ -182,3 +183,11 @@ class FlowController:
     def get_flow_check(self, dpid: str, state="active") -> Optional[dict]:
         """Get flow check."""
         return self.db.flow_checks.find_one({"_id": dpid, "state": state})
+
+    def find_flows(
+        self, query_expression: dict, projection: dict = None
+    ) -> Optional[dict]:
+        """Generic method for getting flows with flexible filtering capabilities."""
+        for flow in self.db.flows.find(query_expression, projection):
+            flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
+            yield flow

--- a/main.py
+++ b/main.py
@@ -482,22 +482,13 @@ class Main(KytosNApp):
         """Retrieve stored flows, where `_id` is excluded in the response.
 
         It is possible dynamically parametrize the switches and state.
-        `dpids` is as a list of dpids separated by comma.
-        If `dpids` is not specified all documents are returned.
+        `dpid` is as a list of dpids separated by comma.
+        If `dpid` is not specified all documents are returned.
         """
         args = request.args
-        dpids = args.getlist("dpids", type=str)
+        dpids = args.getlist("dpid", type=str)
         state = args.get("state", type=str)
-
-        query_expression = {}
-        if dpids:
-            query_expression["switch"] = {"$in": dpids}
-        if state:
-            query_expression["state"] = state
-        projection = {"_id": False}
-        flows_collection = list(
-            self.flow_controller.find_flows(query_expression, projection)
-        )
+        flows_collection = dict(self.flow_controller.find_flows(dpids, state))
         return jsonify(flows_collection)
 
     @listen_to("kytos.flow_manager.flows.(install|delete)")

--- a/openapi.yml
+++ b/openapi.yml
@@ -139,9 +139,11 @@ paths:
         - List
       summary: Retrieve a list of stored flows.
       parameters:
-        - name: dpids
+        - name: dpid
           schema:
             type: array
+            items:
+              type: string
           description: List of switch ids
           required: false
           in: query
@@ -150,7 +152,7 @@ paths:
           in: query
           schema:
             type: string
-          description: state of the flows to retrieve.
+          description: State of the flows to retrieve.
           required: false
           example: "installed"
       responses:
@@ -159,9 +161,14 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/FlowDoc'
+                type: object
+                properties:
+                  switch: 
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FlowDoc'
+        '404':
+          description: Path not found.
   /api/kytos/flow_manager/v2/delete:
     post:
       tags:

--- a/openapi.yml
+++ b/openapi.yml
@@ -133,6 +133,35 @@ paths:
            description: Invalid JSON flow.
         '404':
           description: Datapath not found.
+  /api/kytos/flow_manager/v2/stored_flows:
+    get:
+      tags:
+        - List
+      summary: Retrieve a list of stored flows.
+      parameters:
+        - name: dpids
+          schema:
+            type: array
+          description: List of switch ids
+          required: false
+          in: query
+          example: ["00:00:00:00:00:00:00:01","00:00:00:00:00:00:00:02"]
+        - name: state
+          in: query
+          schema:
+            type: string
+          description: state of the flows to retrieve.
+          required: false
+          example: "installed"
+      responses:
+        '200':
+          description: Operation Successful.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FlowDoc'
   /api/kytos/flow_manager/v2/delete:
     post:
       tags:
@@ -292,3 +321,20 @@ components:
           type: boolean
           description: The force option is for ignoring switch connection errors, and delegating the flows to be automatically sent later on via consistency check.
           default: false
+    FlowDoc:
+      type: object
+      properties:
+        id:
+          type: string
+        switch:
+          type: string
+        flow_id:
+          type: string
+        state:
+          type: string
+        updated_at:
+          type: string
+        flow: 
+          type: object
+          items:
+            $ref: '#/components/schemas/Flow'

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -134,3 +134,11 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         assert self.flow_controller.get_flow_check(self.dpid, state=state)
         args = self.flow_controller.db.flow_checks.find_one.call_args[0]
         assert args[0] == {"_id": self.dpid, "state": state}
+
+    def test_find_flows(self) -> None:
+        """Test find_flows."""
+        state = "installed"
+        assert not list(self.flow_controller.find_flows(dpids=[self.dpid], state=state))
+        args = self.flow_controller.db.flows.find.call_args[0]
+        assert args[0]["switch"]["$in"] == [self.dpid]
+        assert args[0]["state"] == "installed"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -109,73 +109,63 @@ class TestMain(TestCase):
         self.assertEqual(response.json, expected)
         self.assertEqual(response.status_code, 200)
 
-    def test_rest_list_stored_with_dpid(self):
-        """Test list_stored rest method with dpid."""
-        switch_dpid = "00:00:00:00:00:00:00:01"
+    def test_rest_list_stored_all_documents(self):
+        """Test list_stored rest method."""
         flow_dict = {
             "id": 1,
             "flow_id": 1,
             "state": "installed",
-            "flow": {"priority": 10,"cookie": 84114964,"switch":switch_dpid},
+            "flow": {"priority": 10, "cookie": 84114964},
         }
-        
-        self.napp.flow_controller.get_flows.return_value = [flow_dict]
 
-        api = get_test_client(self.napp.controller, self.napp)
-        url = f"{self.API_URL}/v2/stored_flows/00:00:00:00:00:00:00:01"
-
-        response = api.get(url)
-        expected = {"00:00:00:00:00:00:00:01": {"flows":[flow_dict]}}
-        
-        self.assertEqual(response.json, expected)
-        self.assertEqual(response.status_code, 200)
-    
-    def test_rest_list_stored_without_dpid(self):
-        """Test list_stored rest method without dpid."""
-       
-        flow_dict = {
-            "id": 1,
-            "flow_id": 1,
-            "state": "installed",
-            "flow": {"priority": 10,"cookie": 84114964},
-        }
-        flow = MagicMock()
-        flow.as_dict.return_value = flow_dict
-
-        flow_stored = MagicMock()
-        flow_stored.as_dict.return_value = [flow_dict]
-        self.napp.flow_controller.get_flows.return_value = [flow_dict]
+        self.napp.flow_controller.find_flows.return_value = [flow_dict]
 
         api = get_test_client(self.napp.controller, self.napp)
         url = f"{self.API_URL}/v2/stored_flows"
 
         response = api.get(url)
-
-        self.assertEqual(response.json["00:00:00:00:00:00:00:01"]["flows"], [flow_dict])
+        expected = [flow_dict]
+        self.assertEqual(response.json, expected)
         self.assertEqual(response.status_code, 200)
 
-    def test_rest_list_stored_installed(self):
-        """Test list_stored rest method for installed flows."""
-        switch_dpid = "00:00:00:00:00:00:00:01"
+    def test_rest_list_stored_by_state(self):
+        """Test list_stored rest method."""
         flow_dict = {
             "id": 1,
             "flow_id": 1,
             "state": "installed",
-            "flow": {"priority": 10,"cookie": 84114964},
+            "flow": {"priority": 10, "cookie": 84114964},
         }
-        self.napp.flow_controller.get_flows_by_state.return_value = [flow_dict]
+
+        self.napp.flow_controller.find_flows.return_value = [flow_dict]
 
         api = get_test_client(self.napp.controller, self.napp)
-        url = f"{self.API_URL}/v2/stored_flows/00:00:00:00:00:00:00:01?state=installed"
+        url = f"{self.API_URL}/v2/stored_flows?state=installed"
 
         response = api.get(url)
-        expected = {"00:00:00:00:00:00:00:01": {"flows": [flow_dict]}}
-        print(response.json)
+        expected = [flow_dict]
         self.assertEqual(response.json, expected)
-        for flow_i in response.json[switch_dpid]["flows"]:
-            self.assertEqual(flow_i["state"], "installed")
         self.assertEqual(response.status_code, 200)
-    
+
+    def test_rest_list_stored_by_dpids(self):
+        """Test list_stored rest method."""
+        flow_dict = {
+            "id": 1,
+            "flow_id": 1,
+            "state": "installed",
+            "flow": {"priority": 10, "cookie": 84114964},
+        }
+
+        self.napp.flow_controller.find_flows.return_value = [flow_dict]
+
+        api = get_test_client(self.napp.controller, self.napp)
+        url = f"{self.API_URL}/v2/stored_flows?dpids[]=00:00:00:00:00:00:00:01"
+
+        response = api.get(url)
+        expected = [flow_dict]
+        self.assertEqual(response.json, expected)
+        self.assertEqual(response.status_code, 200)
+
     def test_list_flows_fail_case(self):
         """Test the failure case to recover all flows from a switch by dpid.
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -112,59 +112,68 @@ class TestMain(TestCase):
     def test_rest_list_stored_all_documents(self):
         """Test list_stored rest method."""
         flow_dict = {
+            "switch": "00:00:00:00:00:00:00:01",
             "id": 1,
             "flow_id": 1,
             "state": "installed",
             "flow": {"priority": 10, "cookie": 84114964},
         }
 
-        self.napp.flow_controller.find_flows.return_value = [flow_dict]
+        self.napp.flow_controller.find_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [flow_dict]
+        }
 
         api = get_test_client(self.napp.controller, self.napp)
         url = f"{self.API_URL}/v2/stored_flows"
 
         response = api.get(url)
         expected = [flow_dict]
-        self.assertEqual(response.json, expected)
-        self.assertEqual(response.status_code, 200)
+        assert response.json["00:00:00:00:00:00:00:01"] == expected
+        assert response.status_code == 200
 
     def test_rest_list_stored_by_state(self):
         """Test list_stored rest method."""
         flow_dict = {
+            "switch": "00:00:00:00:00:00:00:01",
             "id": 1,
             "flow_id": 1,
             "state": "installed",
             "flow": {"priority": 10, "cookie": 84114964},
         }
 
-        self.napp.flow_controller.find_flows.return_value = [flow_dict]
+        self.napp.flow_controller.find_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [flow_dict]
+        }
 
         api = get_test_client(self.napp.controller, self.napp)
         url = f"{self.API_URL}/v2/stored_flows?state=installed"
 
         response = api.get(url)
-        expected = [flow_dict]
-        self.assertEqual(response.json, expected)
-        self.assertEqual(response.status_code, 200)
+        for swith in response.json:
+            assert response.json[swith][0]["state"] == "installed"
+        assert response.status_code == 200
 
     def test_rest_list_stored_by_dpids(self):
         """Test list_stored rest method."""
         flow_dict = {
+            "switch": "00:00:00:00:00:00:00:01",
             "id": 1,
             "flow_id": 1,
             "state": "installed",
             "flow": {"priority": 10, "cookie": 84114964},
         }
 
-        self.napp.flow_controller.find_flows.return_value = [flow_dict]
+        self.napp.flow_controller.find_flows.return_value = {
+            "00:00:00:00:00:00:00:01": [flow_dict]
+        }
 
         api = get_test_client(self.napp.controller, self.napp)
-        url = f"{self.API_URL}/v2/stored_flows?dpids[]=00:00:00:00:00:00:00:01"
+        url = f"{self.API_URL}/v2/stored_flows?dpid=00:00:00:00:00:00:00:01"
 
         response = api.get(url)
-        expected = [flow_dict]
-        self.assertEqual(response.json, expected)
-        self.assertEqual(response.status_code, 200)
+        for swith in response.json:
+            assert swith == "00:00:00:00:00:00:00:01"
+        assert response.status_code == 200
 
     def test_list_flows_fail_case(self):
         """Test the failure case to recover all flows from a switch by dpid.


### PR DESCRIPTION
Fixed #112 

Endpoints GET v2/stored_flows and GET v2/stored_flows/<dpid> have been added for listing flows from flows collection.

Note that the _id from the database model has been excluded in the response. Also, query parameter filter for state is supported.

Example:

http://localhost:8181/api/kytos/flow_manager/v2/stored_flows?state=pending
{
    "00:00:00:00:00:00:00:01": {
        "flows": []
    },
    "00:00:00:00:00:00:00:02": {
        "flows": []
    },
    "00:00:00:00:00:00:00:03": {
        "flows": []
    }
}

http://localhost:8181/api/kytos/flow_manager/v2/stored_flows/00:00:00:00:00:00:00:01
{
    "00:00:00:00:00:00:00:01": {
        "flows": [
            {
                "flow": {
                    "actions": [
                        {
                            "action_type": "push_vlan",
                            "tag_type": "s"
                        },
                        {
                            "action_type": "set_vlan",
                            "vlan_id": 3824
                        },
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ],
                    "cookie": 12310228866111668291,
                    "hard_timeout": 0,
                    "idle_timeout": 0,
                    "match": {
                        "in_port": 1
                    },
                    "priority": 32768,
                    "table_id": 0
                },
                "flow_id": "0d024b8d679624d6c87239f0cc2bb1c8",
                "id": "76b58fe1f80f427206009531bb6616e5",
                "inserted_at": "2022-09-13T17:48:51",
                "state": "installed",
                "switch": "00:00:00:00:00:00:00:01",
                "updated_at": "2022-10-02T04:52:55"
            },
            {
                "flow": {
                    "actions": [
                        {
                            "action_type": "pop_vlan"
                        },
                        {
                            "action_type": "output",
                            "port": 1
                        }
                    ],
                    "cookie": 12310228866111668291,
                    "hard_timeout": 0,
                    "idle_timeout": 0,
                    "match": {
                        "dl_vlan": 3824,
                        "in_port": 2
                    },
                    "priority": 32768,
                    "table_id": 0
                },
                "flow_id": "6ea12166476c089c7fb8c868761032d2",
                "id": "3158527bb612c4cbb6069ff669598d30",
                "inserted_at": "2022-09-22T21:00:44",
                "state": "installed",
                "switch": "00:00:00:00:00:00:00:01",
                "updated_at": "2022-10-02T04:52:55"
            },
            {
                "flow": {
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 4294967293
                        }
                    ],
                    "cookie": 12321848580485677057,
                    "hard_timeout": 0,
                    "idle_timeout": 0,
                    "match": {
                        "dl_type": 35020,
                        "dl_vlan": 3799
                    },
                    "priority": 1000,
                    "table_id": 0
                },
                "flow_id": "5cd66b3ec5c0437b3d163f18e8491250",
                "id": "79954d8533ddf92c68de139d5fbc0451",
                "inserted_at": "2022-09-09T18:20:27",
                "state": "installed",
                "switch": "00:00:00:00:00:00:00:01",
                "updated_at": "2022-10-03T07:42:23"
            }
        ]
    }
}