### PR TITLE
[Fix] Consistency check to run immediately when FlowStats is first received

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 Fixed
 =====
 - Fixed handling ``OFPT_ERROR`` correctly when OF negotiation fails
+- Fixed consistency check to run immediately when FlowStats is first received.
 
 Changed
 =======


### PR DESCRIPTION
Fixes #114 

- Fixed consistency check to run immediately when FlowStats is first received.

## Local tests

### Using this branch

- Once FlowStats is first received and consistency check started, after 4ms in the same cycle, it detected a missing flow:

```
kytos $> 2022-10-24 11:02:58,745 - INFO [kytos.core.atcp_server] [atcp_server.py:131:connection_made] (MainThread) New connection from 127.0.0.1:57598
2022-10-24 11:02:58,746 - INFO [kytos.core.atcp_server] [atcp_server.py:182:connection_lost] (MainThread) Connection lost with client 127.0.0.1:57598. Reason: Request closed by client
2022-10-24 11:02:58,851 - INFO [kytos.core.atcp_server] [atcp_server.py:131:connection_made] (MainThread) New connection from 127.0.0.1:57612
2022-10-24 11:02:58,858 - INFO [kytos.napps.kytos/of_core] [main.py:138:handle_features_reply] (thread_pool_sb_0) Connection ('127.0.0.1', 57612), Switch 00:00:00:00:00:00:00:01: OPENFLO
W HANDSHAKE COMPLETE
2022-10-24 11:02:58,877 - INFO [kytos.napps.kytos/flow_manager] [main.py:571:_send_flow_mods_from_request] (Thread-93) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: a
dd, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'outp
ut', 'port': 4294967293}]}]}
2022-10-24 11:02:58,887 - INFO [werkzeug] [_internal.py:225:_log] (Thread-93) 127.0.0.1 - - [24/Oct/2022 11:02:58] "POST /api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01 HTTP/1.1
" 202 -
2022-10-24 11:03:00,380 - INFO [kytos.napps.kytos/flow_manager] [main.py:333:check_consistency] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 has started
2022-10-24 11:03:00,384 - INFO [kytos.napps.kytos/flow_manager] [main.py:361:check_missing_flows] (thread_pool_sb_2) Consistency check: missing flow on switch 00:00:00:00:00:00:00:01.
2022-10-24 11:03:00,385 - INFO [kytos.napps.kytos/flow_manager] [main.py:365:check_missing_flows] (thread_pool_sb_2) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be installed. Flo
w: {'flows': [{'cookie': 0, 'match': {'in_port': 1, 'dl_vlan': 105}, 'actions': [{'action_type': 'output', 'port': 1}], 'table_id': 0, 'priority': 101, 'idle_timeout': 0, 'hard_timeout':
 0}]}
2022-10-24 11:03:00,385 - INFO [kytos.napps.kytos/flow_manager] [main.py:336:check_consistency] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 is done
kytos $>
```

- Testing out with an alien flow, 6ms after in the same cycle the alien flow was detected:

```
2022-10-24 11:06:50,899 - INFO [kytos.napps.kytos/flow_manager] [main.py:336:check_consistency] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 is done
2022-10-24 11:06:51,699 - INFO [kytos.core.atcp_server] [atcp_server.py:182:connection_lost] (MainThread) Connection lost with client 127.0.0.1:57612. Reason: Request closed by client
2022-10-24 11:07:10,153 - INFO [kytos.core.atcp_server] [atcp_server.py:131:connection_made] (MainThread) New connection from 127.0.0.1:37000
2022-10-24 11:07:10,663 - INFO [kytos.napps.kytos/of_core] [main.py:138:handle_features_reply] (thread_pool_sb_2) Connection ('127.0.0.1', 37000), Switch 00:00:00:00:00:00:00:01: OPENFLO
W HANDSHAKE COMPLETE
2022-10-24 11:07:10,692 - INFO [kytos.napps.kytos/flow_manager] [main.py:571:_send_flow_mods_from_request] (Thread-102) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command:
add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'out
put', 'port': 4294967293}]}]}
2022-10-24 11:07:10,698 - INFO [werkzeug] [_internal.py:225:_log] (Thread-102) 127.0.0.1 - - [24/Oct/2022 11:07:10] "POST /api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01 HTTP/1.
1" 202 -
kytos $>

kytos $> 2022-10-24 11:07:12,203 - INFO [kytos.napps.kytos/flow_manager] [main.py:333:check_consistency] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 has starte
d
2022-10-24 11:07:12,209 - INFO [kytos.napps.kytos/flow_manager] [main.py:408:check_alien_flows] (thread_pool_sb_0) Consistency check: alien flow on switch 00:00:00:00:00:00:00:01
2022-10-24 11:07:12,210 - INFO [kytos.napps.kytos/flow_manager] [main.py:413:check_alien_flows] (thread_pool_sb_0) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be deleted. Flow: {
'flows': [{'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 1000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 4097, 'id': '13bc34e4a7a3d61cd0d
0ebb7c49991ff', 'stats': {'byte_count': 0, 'duration_sec': 9, 'duration_nsec': 789000000, 'packet_count': 0}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'ac
tions': [{'port': 2, 'action_type': 'output'}]}]}]}
2022-10-24 11:07:12,217 - INFO [kytos.napps.kytos/flow_manager] [main.py:336:check_consistency] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 is done
kytos $>

```

### Using the current master branch

- Notice below that it took more than one consistency check cycle to confirm that it was missing (so, it wasn't taking advantage of this initial iteration that could've been react promptly):

```
kytos $> 2022-10-24 11:16:58,262 - INFO [kytos.core.atcp_server] [atcp_server.py:131:connection_made] (MainThread) New connection from 127.0.0.1:37328
2022-10-24 11:16:58,770 - INFO [kytos.napps.kytos/of_core] [main.py:138:handle_features_reply] (thread_pool_sb_0) Connection ('127.0.0.1', 37328), Switch 00:00:00:00:00:00:00:01: OPENFL
OW HANDSHAKE COMPLETE
2022-10-24 11:16:58,807 - INFO [kytos.napps.kytos/flow_manager] [main.py:569:_send_flow_mods_from_request] (Thread-93) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command:
add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'ou
tput', 'port': 4294967293}]}]}
2022-10-24 11:16:58,814 - INFO [werkzeug] [_internal.py:225:_log] (Thread-93) 127.0.0.1 - - [24/Oct/2022 11:16:58] "POST /api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01 HTTP/1.
1" 202 -
2022-10-24 11:17:00,298 - INFO [kytos.napps.kytos/flow_manager] [main.py:331:check_consistency] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 has started
2022-10-24 11:17:00,308 - INFO [kytos.napps.kytos/flow_manager] [main.py:334:check_consistency] (thread_pool_sb_2) check_consistency on switch 00:00:00:00:00:00:00:01 is done
kytos $>
kytos $>

kytos $> 2022-10-24 11:18:27,804 - INFO [kytos.napps.kytos/flow_manager] [main.py:331:check_consistency] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 has start
ed
2022-10-24 11:18:27,816 - INFO [kytos.napps.kytos/flow_manager] [main.py:359:check_missing_flows] (thread_pool_sb_0) Consistency check: missing flow on switch 00:00:00:00:00:00:00:01.
2022-10-24 11:18:27,821 - INFO [kytos.napps.kytos/flow_manager] [main.py:363:check_missing_flows] (thread_pool_sb_0) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be installed. Fl
ow: {'flows': [{'cookie': 0, 'match': {'in_port': 1, 'dl_vlan': 105}, 'actions': [{'action_type': 'output', 'port': 1}], 'table_id': 0, 'priority': 101, 'idle_timeout': 0, 'hard_timeout
': 0}]}
2022-10-24 11:18:27,822 - INFO [kytos.napps.kytos/flow_manager] [main.py:334:check_consistency] (thread_pool_sb_0) check_consistency on switch 00:00:00:00:00:00:00:01 is done
kytos $>
```