### PR TITLE
[Fix] FlowSubDoc model `instructions`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 =====
 - Fixed handling ``OFPT_ERROR`` correctly when OF negotiation fails
 - Fixed consistency check to run immediately when FlowStats is first received.
+- Fixed flow ``instructions`` to be stored.
 
 Changed
 =======

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -98,6 +98,7 @@ class FlowSubDoc(BaseModel):
     hard_timeout = 0
     match: Optional[MatchSubDoc]
     actions: Optional[List[dict]]
+    instructions: Optional[List[dict]]
 
     class Config:
         """Config."""

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -1,0 +1,30 @@
+"""TestDbModels."""
+
+from napps.kytos.flow_manager.db.models import FlowDoc
+
+
+class TestDbModels:
+    """TestDbModels."""
+
+    def test_flow_doct(self) -> None:
+        """Test FlowDoc."""
+        flow_dict = {
+            "priority": 100,
+            "match": {"in_port": 11, "dl_vlan": 3503, "dl_type": 2048, "nw_proto": 6},
+            "instructions": [
+                {
+                    "instruction_type": "apply_actions",
+                    "actions": [{"action_type": "push_int"}],
+                },
+                {"instruction_type": "goto_table", "table_id": 2},
+            ],
+        }
+        data = {
+            "switch": "00:00:00:00:00:00:00:01",
+            "flow_id": "1",
+            "id": "0",
+            "flow": flow_dict,
+        }
+        flow_doc = FlowDoc(**data)
+        assert flow_doc
+        assert flow_doc.flow.instructions == flow_dict["instructions"]


### PR DESCRIPTION
Fixes #117 

This PR is on top of PR #115 

Thanks @italovalcy for catching this, and the initial patch. 

### Local tests

With this PR I provisioned one EPL to make sure no other side effects happend, worked as usual. 

```
2022-10-31 13:07:45,463 - INFO [kytos.napps.kytos/mef_eline] [evc.py:672:deploy_to_path] (Thread-100) EVC(5cac9d46e6fc41, epl) was deployed.
```

@italovalcy it'd be great if you could try out this branch in the original scenario, thanks. 