### PR TITLE
[Fix] AttributeError: 'NoneType' object has no attribute 'protocol'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixed
 - Fixed handling ``OFPT_ERROR`` correctly when OF negotiation fails
 - Fixed consistency check to run immediately when FlowStats is first received.
 - Fixed flow ``instructions`` to be stored.
+- Handled connection exception corner case before an OpenFlow handshake
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -445,7 +445,11 @@ class Main(KytosNApp):
                         continue
                     if match_flow(
                         flow_dict["flow"],
-                        switches[dpid].connection.protocol.version,
+                        switches[dpid].connection.protocol.version
+                        if dpid in switches
+                        and switches[dpid].connection
+                        and switches[dpid].connection.protocol
+                        else 0x04,
                         stored_flow["flow"],
                     ):
                         stored_flow["state"] = FlowEntryState.DELETED.value


### PR DESCRIPTION
Fixes #120 

- Handled connection exception corner case before an OpenFlow handshake. If the connection isn't set yet, then it'll fallback to version 0x04, same approach that we have on our `FlowFactory`.

Explored it locally, the API response status code behaves as you'd expect `202` or `424`:

```
kytos $> controller.switches['00:00:00:00:00:00:00:01'].connection = None
kytos $> 2022-11-10 17:48:53,435 - INFO [kytos.napps.kytos/flow_manager] [main.py:589:_send_flow_mods_from_request] (Thread-140) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01
, command: add, force: False, flows_dict: {'force': False, 'flows': [{'priority': 101, 'match': {'in_port': 1, 'dl_vlan': 105}, 'actions': [{'action_type': 'output', 'port': 1}]}]}
2022-11-10 17:48:53,476 - INFO [werkzeug] [_internal.py:225:_log] (Thread-140) 127.0.0.1 - - [10/Nov/2022 17:48:53] "POST /api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01 HTTP/
1.1" 424 -
2022-11-10 17:48:58,883 - INFO [kytos.napps.kytos/flow_manager] [main.py:589:_send_flow_mods_from_request] (Thread-141) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command
: add, force: True, flows_dict: {'force': True, 'flows': [{'priority': 101, 'match': {'in_port': 1, 'dl_vlan': 105}, 'actions': [{'action_type': 'output', 'port': 1}]}]}
2022-11-10 17:48:58,890 - INFO [werkzeug] [_internal.py:225:_log] (Thread-141) 127.0.0.1 - - [10/Nov/2022 17:48:58] "POST /api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01 HTTP/
1.1" 202 -
kytos $>
```

Thanks for catching this @jab1982 and @italovalcy for investigating 