### PR TITLE
Filter for state=installed by default

### DIFF
--- a/main.py
+++ b/main.py
@@ -479,7 +479,8 @@ class Main(KytosNApp):
 
     @rest("v2/stored_flows")
     def list_stored(self):
-        """Retrieve stored flows, where `_id` is excluded in the response.
+        """Retrieve stored flows (only installed flows by default),
+        where `_id` is excluded in the response.
 
         It is possible dynamically parametrize the switches and state.
         `dpid` is as a list of dpids separated by comma.
@@ -488,6 +489,8 @@ class Main(KytosNApp):
         args = request.args
         dpids = args.getlist("dpid", type=str)
         state = args.get("state", type=str)
+        if state is None:
+            state = "installed"
         flows_collection = dict(self.flow_controller.find_flows(dpids, state))
         return jsonify(flows_collection)
 

--- a/main.py
+++ b/main.py
@@ -495,8 +495,6 @@ class Main(KytosNApp):
         args = request.args
         dpids = args.getlist("dpid", type=str)
         state = args.get("state", type=str)
-        if state is None:
-            state = "installed"
         flows_collection = dict(self.flow_controller.find_flows(dpids, state))
         return jsonify(flows_collection)
 


### PR DESCRIPTION
Fix [issue 54 from sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp/issues/54)

Now on the `flow_manager/v2/stored_flows` endpoint, only installed flows are filtered if no state is specified. 
This endpoint is used in function get_stored_flows() of sdntrace_cp.

See [change](https://github.com/kytos-ng/flow_manager/blob/09f4c6acf8f1561a386eef9fe291675c3b0d70eb/main.py#L492)

I wonder if it's better this way or if I should just filter it for sdntrace_cp