### PR TITLE
[release] Bumped 2022.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,15 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.0] - 2022-12-15
+***********************
+
 Added
 =====
 
 - Added endpoint ``GET v2/stored_flows`` for listing flows from flows collection. Query parameter filter for `state` and `dpid` is supported. A list of flows per switch is returned.
-- Added query paramater filter for `cookie_range` to the endpoint ``GET v2/stored_flows``.
-- Added query paramater filter for `state` to the endpoint ``GET v2/stored_flows``.
+- Added query parameter filter for `cookie_range` to the endpoint ``GET v2/stored_flows``.
+- Added query parameter filter for `state` to the endpoint ``GET v2/stored_flows``.
 
 Fixed
 =====
@@ -21,19 +24,11 @@ Fixed
 - Fixed flow ``instructions`` to be stored.
 - Handled connection exception corner case before an OpenFlow handshake
 
-Changed
-=======
-
-Deprecated
-==========
-
 Removed
 =======
 - Removed support for OpenFlow 1.0
-- Removed `serializers` package
+- Removed ``serializers`` package
 
-Security
-========
 
 [2022.2.0] - 2022-08-08
 ***********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2022.2.0",
+  "version": "2022.3.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",


### PR DESCRIPTION
Closes N/A

### Summary

- Bumped 2022.3.0

I'm bumping the version of NApps that can already be bumped, when the time comes, it's just a matter of merging and creating the GitHub release with its `git` tag. 