### PR TITLE
[fix] Fixed `cookie_mask` query to match a range of cookies

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -795,7 +795,7 @@ class TestMain(TestCase):
         flow1.__getitem__.side_effect = flow1_dict.__getitem__
         flows = [flow1]
         switch.flows = flows
-        self.napp.flow_controller.get_flows_by_cookies.return_value = {
+        self.napp.flow_controller.get_flows_by_cookie_ranges.return_value = {
             switch.id: [flow1_dict]
         }
         self.napp.delete_matched_flows([flow1_dict], {switch.id: switch})
@@ -827,7 +827,7 @@ class TestMain(TestCase):
         flow1.__getitem__.side_effect = flow1_dict.__getitem__
         flows = [flow1]
         switch.flows = flows
-        self.napp.flow_controller.get_flows_by_cookies.return_value = {
+        self.napp.flow_controller.get_flows_by_cookie_ranges.return_value = {
             switch.id: [flow1_dict]
         }
         self.napp.delete_matched_flows([flow1_dict], {switch.id: switch})


### PR DESCRIPTION
Closes #129

### Summary

- Fixed `cookie_mask` query to match a range of cookies. 
- Implemented the query solution mentioned on this comment https://github.com/kytos-ng/flow_manager/issues/129#issuecomment-1363206096, aggregating the (merged) cookie ranges with an `"$or"` operator, I've also checked on MongoDB that the index is being hit correctly.

Also, to recap, FYI, flow_manager still doesn't validate completely the payload on this endpoint, so invalid type or values can lead to issues, but that will be covered on issue #43

### End-to-End Tests

I've added three new e2e tests to cover the ranges with `cookie_mask` on another PR https://github.com/kytos-ng/kytos-end-to-end-tests/pull/197, to also cover the original issue that Italo has caught, and ran `flow_manager` related tests again:


```
+ python3 -m pytest tests/ --timeout=600 -k flow_manager
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0
timeout: 600.0s
timeout method: signal
timeout func_only: False
collected 204 items / 154 deselected / 50 selected

tests/test_e2e_20_flow_manager.py ..................                     [ 36%]
tests/test_e2e_21_flow_manager.py ..                                     [ 40%]
tests/test_e2e_22_flow_manager.py ...............                        [ 71%]
tests/test_e2e_23_flow_manager.py ...............                        [100%]

------------------------------- start/stop times -------------------------------
======== 50 passed, 154 deselected, 137 warnings in 2625.36s (0:43:45) =========
```

I've also dispatched the entire e2e test suite for complenetess, I'll post the results with this branch later.

I'll be back on Jan 31. 
