### PR TITLE
Add support to str for dl_type

### DIFF
--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -50,7 +50,7 @@ class MatchSubDoc(BaseModel):
     dl_src: Optional[str]
     dl_dst: Optional[str]
     dl_type: Optional[int]
-    dl_vlan: Union[int, str]
+    dl_vlan: Union[int, str, None]
     dl_vlan_pcp: Optional[int]
     nw_src: Optional[str]
     nw_dst: Optional[str]

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -6,7 +6,7 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from bson.decimal128 import Decimal128
 from pydantic import BaseModel, Field, validator
@@ -50,7 +50,7 @@ class MatchSubDoc(BaseModel):
     dl_src: Optional[str]
     dl_dst: Optional[str]
     dl_type: Optional[int]
-    dl_vlan: Optional[int]
+    dl_vlan: Union[int, str]
     dl_vlan_pcp: Optional[int]
     nw_src: Optional[str]
     nw_dst: Optional[str]

--- a/openapi.yml
+++ b/openapi.yml
@@ -252,9 +252,11 @@ components:
           type: string
           example: '00:15:af:d5:38:98'
         dl_type:
-          type: integer
-          format: int16
-          example: 2048
+          oneOf:
+            - type: integer
+              format: int32
+            - type: string
+          example: 2048, any
         dl_vlan:
           type: integer
           format: int16


### PR DESCRIPTION
Related to mef_eline PR [#258](https://github.com/kytos-ng/mef_eline/pull/258)

### Summary
`dl_type` in a flow can now accept `string` values

### Local Tests
Flow received
```
2023-02-08 12:30:40,999 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) Flow forwarded to switch 00:00:00:00:00:00:00:01 to be deleted. Flow: {'flows': [{'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vlan': '0/0'}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12263066888382572876, 'id': '743158efbd47ba03670cc9c8478ce6ec', 'stats': {'byte_count': 0, 'duration_sec': 33, 'duration_nsec': 64000000, 'packet_count': 0}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'vlan_id': 24, 'action_type': 'set_vlan'}, {'port': 2, 'action_type': 'output'}]}]}]}

```
REMINDER: Tests missing.