### PR TITLE
feat: release 2022.3.1: handled PackException to return bad request if a flow can't be packed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2023-02-17
+***********************
+
+Added
+=====
+- Handled ``PackException`` to return bad request if a flow can't be packed.
+
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from napps.kytos.of_core.settings import STATS_INTERVAL
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
 from pyof.v0x04.asynchronous.error_msg import ErrorType
 from pyof.v0x04.common.header import Type
+from pyof.foundation.exceptions import PackException
 from werkzeug.exceptions import (
     BadRequest,
     FailedDependency,
@@ -623,6 +624,8 @@ class Main(KytosNApp):
 
         except SwitchNotConnectedError as error:
             raise FailedDependency(str(error))
+        except PackException as error:
+            raise BadRequest(str(error))
 
     def _install_flows(
         self,
@@ -650,6 +653,7 @@ class Main(KytosNApp):
             for flow_dict in flows_list:
                 flow = serializer.from_dict(flow_dict, switch)
                 flow_mod = build_flow_mod_from_command(flow, command)
+                flow_mod.pack()
                 flow_mods.append(flow_mod)
                 flows.append(flow)
                 flow_dicts.append(

--- a/main.py
+++ b/main.py
@@ -13,9 +13,9 @@ from napps.kytos.of_core.flow import FlowFactory
 from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_core.settings import STATS_INTERVAL
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from pyof.foundation.exceptions import PackException
 from pyof.v0x04.asynchronous.error_msg import ErrorType
 from pyof.v0x04.common.header import Type
-from pyof.foundation.exceptions import PackException
 from werkzeug.exceptions import (
     BadRequest,
     FailedDependency,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -240,6 +240,15 @@ class TestMain(TestCase):
 
         self.assertEqual(mock_install_flows.call_count, 2)
 
+    def test_rest_add_pack_exc(self):
+        """Test add pack exception."""
+        api = get_test_client(self.napp.controller, self.napp)
+        url = f"{self.API_URL}/v2/flows"
+        response = api.post(url, json={"flows": [{"cookie": 27115650311270694912}]})
+        self.assertEqual(response.status_code, 400)
+        data = response.json
+        assert "FlowMod.cookie" in data["description"]
+
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_rest_add_and_delete_with_dpid(self, mock_install_flows):
         """Test add and delete rest method with dpid."""


### PR DESCRIPTION
Closes #136 

Related to https://github.com/kytos-ng/of_core/issues/102

### Summary

See updated changelog file

### Local Tests

Tested out a request with a overflowed cookie

```
{
    "code": 400,
    "description": "FlowMod.cookie - Expected UBInt64, found value \"27115650311270694912\" of type int",
    "name": "Bad Request"
}
```

### End-to-End Tests

I'll run with the rest of the related changes
