### PR TITLE
fix: release 2022.3.1: Fixed not iterable error when sending a FlowMod during OpenFlow connection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ file.
 Added
 =====
 - Handled ``PackException`` to return bad request if a flow can't be packed.
+- Fixed not iterable error when sending a FlowMod during OpenFlow connection.
 
 
 [2022.3.0] - 2022-12-15

--- a/main.py
+++ b/main.py
@@ -270,6 +270,8 @@ class Main(KytosNApp):
         Returns:
             bool: True if retried, False if max retries have been reached.
         """
+        if event.message.header.message_type != Type.OFPT_FLOW_MOD:
+            return False
         if max_retries <= 0:
             raise ValueError(f"max_retries: {max_retries} should be > 0")
 
@@ -313,7 +315,7 @@ class Main(KytosNApp):
             flow_mod.header.xid = xid
             self._send_flow_mod(flow.switch, flow_mod)
             if send_barrier:
-                self._send_barrier_request(flow.switch, flow_mod)
+                self._send_barrier_request(flow.switch, [flow_mod])
             return True
         except SwitchNotConnectedError:
             log.info(f"Switch {switch.id} isn't connected, it'll retry.")


### PR DESCRIPTION
Closes #131 

This PR is on top of PR #137 since both will land as a patch for 2022.3.1

### Summary

See updated changelog file

### Local Tests

I simulated OpenFlow connection errors in addition to the unit tests, the retries went as expected:

```
kytos $> 2023-02-20 18:25:53,402 - INFO [kytos.napps.kytos/flow_manager] [main.py:603:_send_flow_mods_from_request] (Thread-103) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01,
 command: add, force: False, flows_dict: {'force': False, 'flows': [{'priority': 101, 'cookie': 100, 'match': {'in_port': 1}, 'actions': [{'action_type': 'output', 'port': 2}]}]}
2023-02-20 18:25:53,408 - INFO [kytos.core.controller] [controller.py:640:msg_out_event_handler] (MainThread) connection closed. Cannot send message
2023-02-20 18:25:54,412 - INFO [kytos.napps.kytos/flow_manager] [main.py:309:_retry_on_openflow_connection_error] (thread_pool_sb_0) Retry attempt: 1 for xid: 1542634650 on switch: 00:0
0:00:00:00:00:00:01, accumulated wait: 1, command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 101, 'idle_timeout': 0, 'hard_tim
eout': 0, 'cookie': 100, 'id': 'e9f2666ab92eb6eed5b3a80189333c45', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_
type': 'output'}]}]}
2023-02-20 18:25:54,418 - INFO [kytos.core.controller] [controller.py:640:msg_out_event_handler] (MainThread) connection closed. Cannot send message
kytos $>                                                                                                                                                                                 

kytos $>                                                                                                                                                                                 

kytos $> 2023-02-20 18:25:55,412 - INFO [kytos.napps.kytos/flow_manager] [main.py:309:_retry_on_openflow_connection_error] (thread_pool_sb_7) Retry attempt: 2 for xid: 1542634650 on swi
tch: 00:00:00:00:00:00:00:01, accumulated wait: 2, command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 101, 'idle_timeout': 0, 
'hard_timeout': 0, 'cookie': 100, 'id': 'e9f2666ab92eb6eed5b3a80189333c45', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2,
 'action_type': 'output'}]}]}
2023-02-20 18:25:55,417 - INFO [kytos.core.controller] [controller.py:640:msg_out_event_handler] (MainThread) connection closed. Cannot send message
2023-02-20 18:25:58,431 - INFO [kytos.napps.kytos/flow_manager] [main.py:309:_retry_on_openflow_connection_error] (thread_pool_sb_6) Retry attempt: 3 for xid: 1542634650 on switch: 00:0
0:00:00:00:00:00:01, accumulated wait: 4, command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 101, 'idle_timeout': 0, 'hard_tim
eout': 0, 'cookie': 100, 'id': 'e9f2666ab92eb6eed5b3a80189333c45', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_
type': 'output'}]}]}
2023-02-20 18:25:58,435 - INFO [kytos.core.controller] [controller.py:640:msg_out_event_handler] (MainThread) connection closed. Cannot send message
2023-02-20 18:25:58,437 - WARNING [kytos.napps.kytos/flow_manager] [main.py:292:_retry_on_openflow_connection_error] (thread_pool_sb_1) Max retries: 3 for xid: 1542634650 has been reach
ed on switch 00:00:00:00:00:00:00:01, command: add, flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1}, 'priority': 101, 'idle_timeout': 0, 'hard_timeout
': 0, 'cookie': 100, 'id': 'e9f2666ab92eb6eed5b3a80189333c45', 'stats': {}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type
': 'output'}]}]}
kytos $>                                                                                                                                                                                 

kytos $>                                                                                                                                                                                 

kytos $> 2023-02-20 18:26:15,959 - INFO [kytos.napps.kytos/flow_manager] [main.py:603:_send_flow_mods_from_request] (Thread-104) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01,
 command: add, force: False, flows_dict: {'force': False, 'flows': [{'priority': 102, 'cookie': 100, 'match': {'in_port': 1}, 'actions': [{'action_type': 'output', 'port': 2}]}]}
kytos $>                                                                                                                                                                                 

```

### End-to-End Tests

e2e tests were run for the PR that this branch is on top of, no surprises expected since we don't have explicit e2e simulating this failure yet.
