### PR TITLE
feature: Sort the stored flows returned with `flow_manager/v2/stored_flows`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- Update endpoint ``GET v2/stored_flows`` to return the flows in descending order by `priority`.
+
 [2022.3.1] - 2023-02-17
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -46,12 +46,14 @@ class FlowController:
         index_tuples = [
             ("flows", [("flow_id", pymongo.ASCENDING)], {"unique": True}),
             ("flows", [("flow.cookie", pymongo.ASCENDING)], {}),
+            ("flows", [("flow.priority", pymongo.ASCENDING)], {}),
             ("flows", [("state", pymongo.ASCENDING)], {}),
             (
                 "flows",
                 [
                     ("switch", pymongo.ASCENDING),
                     ("flow.cookie", pymongo.ASCENDING),
+                    ("flow.priority", pymongo.ASCENDING),
                     ("state", pymongo.ASCENDING),
                     ("inserted_at", pymongo.ASCENDING),
                     ("updated_at", pymongo.ASCENDING),
@@ -197,7 +199,9 @@ class FlowController:
 
     def _find_flows(self, query_expression: dict, projection: dict) -> Optional[dict]:
         """Generic method to look for flows given a query and projection"""
-        flows = self.db.flows.find(query_expression, projection)
+        flows = self.db.flows.find(query_expression, projection).sort(
+            [("flow.priority", -1), ("updated_at", 1)]
+        )
         flows_by_dpid = {}
         for flow in flows:
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())

--- a/openapi.yml
+++ b/openapi.yml
@@ -160,7 +160,7 @@ paths:
           schema:
             type: array
             items:
-              type: int
+              type: integer
           description: Range of cookies
           required: false
           example: [84114963, 84114965]

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -35,12 +35,14 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         expected_indexes = [
             ("flows", [("flow_id", 1)]),
             ("flows", [("flow.cookie", 1)]),
+            ("flows", [("flow.priority", 1)]),
             ("flows", [("state", 1)]),
             (
                 "flows",
                 [
                     ("switch", 1),
                     ("flow.cookie", 1),
+                    ("flow.priority", 1),
                     ("state", 1),
                     ("inserted_at", 1),
                     ("updated_at", 1),

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -162,3 +162,10 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         assert args[0]["state"] == "installed"
         assert args[0]["flow.cookie"]["$gte"] == Decimal128(Decimal(cookie_range[0]))
         assert args[0]["flow.cookie"]["$lte"] == Decimal128(Decimal(cookie_range[1]))
+
+    def test_find_flows_sorted(self) -> None:
+        """Test find_flows to sort flows."""
+        assert not list(self.flow_controller.find_flows())
+        assert self.flow_controller.db.flows.find().sort.call_count == 1
+        args = self.flow_controller.db.flows.find().sort.call_args[0]
+        assert args[0] == [("flow.priority", -1), ("updated_at", 1)]


### PR DESCRIPTION
Closes #139 

### Summary

Sort the flows that are obtained with a request of stored flows with [`find_flows`](https://github.com/kytos-ng/flow_manager/blob/3957bdc61af593b536b39313b3e32d0473a6c597/controllers/__init__.py#L202-L204)

### Local Tests

Requiest: 
```
http://127.0.0.1:8181/api/kytos/flow_manager/v2/stored_flows?dpid=00:00:00:00:00:00:00:02&state=installed
```

Response:
```
{
    "00:00:00:00:00:00:00:02": [
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "set_vlan",
                        "vlan_id": 4001
                    },
                    {
                        "action_type": "output",
                        "port": 3
                    }
                ],
                "cookie": 12310228866111668291,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 3824,
                    "in_port": 2
                },
                "priority": 32768,
                "table_id": 0
            },
            "flow_id": "c7d11070198ebad1796b22c6d215c74b",
            "id": "dee0f288ec9aed48d4ce2d466ebf7e46",
            "inserted_at": "2022-09-22T21:00:44",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:02",
            "updated_at": "2023-03-03T22:26:59"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "set_vlan",
                        "vlan_id": 3824
                    },
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 12310228866111668291,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 4001,
                    "in_port": 3
                },
                "priority": 32768,
                "table_id": 0
            },
            "flow_id": "e56d326406a2c309f260c20bf6b8ece1",
            "id": "315f61612ffa8bbb438192d42c12c2ca",
            "inserted_at": "2022-09-22T21:00:44",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:02",
            "updated_at": "2023-03-03T22:26:59"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 4294967293
                    }
                ],
                "cookie": 12321848580485677058,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_type": 35020,
                    "dl_vlan": 3799
                },
                "priority": 1000,
                "table_id": 0
            },
            "flow_id": "23bfec0be8fabf35e1e74c2307b3b0a8",
            "id": "187e17beddc51a7ea8f1c084ce8ec1c5",
            "inserted_at": "2022-09-09T18:20:27",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:02",
            "updated_at": "2023-03-03T23:05:55"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 0,
                "hard_timeout": 1200,
                "idle_timeout": 360,
                "match": {
                    "in_port": 1
                },
               "priority": 10,
                "table_id": 0
            },
            "flow_id": "1c0149e7675269672abb6858abd87fed",
            "id": "0962e2d6d4959a6a05e60dc564fada88",
            "inserted_at": "2023-03-03T22:25:25",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:02",
            "updated_at": "2023-03-03T22:56:35"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 4294967293
                    }
                ],
                "cookie": 0,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "priority": 0,
                "table_id": 0
            },
            "flow_id": "2e8155af1a85644a166b28deb5af1f79",
            "id": "61c492f52e9e9271b05ba983b60b29b5",
            "inserted_at": "2022-10-10T20:29:41",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:02",
            "updated_at": "2023-03-03T22:26:59"
        }
    ]
}
```

Note that now the flows are ordered by `priority`.

### End-to-End Tests

Added `test_017_install_flows_and_retrieve_sorted` into `test_e2e_20_flow_manager.py`. Three flows are installed and it is verified that they are returned in descending order by `priority`.

+ python3 -m pytest tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_017_install_flows_and_retrieve_sorted
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_20_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================
test_e2e_20_flow_manager.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_20_flow_manager.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 34 warnings in 143.86s (0:02:23) ==================