### PR TITLE
feat: basic validation for ``cookie`` and ``cookie_mask`` when installing or removing flows.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 - Added support for VLAN with mask. ``dl_vlan`` now also supports a string ``"vlan/mask"``.
 - Added two new fields to the collection ``flows``. ``owner`` has the name of the NApp that created the flow. ``table_group`` is the classification of a flow, for example: ``epl``, ``base`` and ``evpl``.
 - Added new script ``pipeline_related.py`` to add new fields ``owner`` and ``table_group`` to the flows on the collection ``flows`` on MongoDB
+- Added basic validation for ``cookie`` and ``cookie_mask`` when installing or removing flows.
 
 Changed
 =======

--- a/exceptions.py
+++ b/exceptions.py
@@ -5,6 +5,16 @@ class InvalidCommandError(Exception):
     """Command has an invalid value."""
 
 
+class FlowSerializerError(Exception):
+    """FlowSerializerError."""
+
+    def __init__(self, message, flow_dict=None):
+        """Constructor."""
+        self.message = message
+        self.flow_dict = flow_dict
+        super().__init__(message)
+
+
 class SwitchNotConnectedError(Exception):
     """Exception raised when a switch's connection isn't connected."""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -242,6 +242,42 @@ class TestMain:
         data = response.json()
         assert "FlowMod.cookie" in data["description"]
 
+    async def test_rest_add_flow_serializer_type_error(self, event_loop):
+        """Test add flow serializer type error exception."""
+        self.napp.controller.loop = event_loop
+        body = {
+            "flows": [
+                {
+                    "priority": 101,
+                    "match": {"in_port": 1},
+                    "actions": [{"action_type": "output", "portx": 1}],
+                }
+            ],
+        }
+        endpoint = f"{self.base_endpoint}/flows"
+        response = await self.api_client.post(endpoint, json=body)
+        assert response.status_code == 400
+        data = response.json()
+        assert "portx" in data["description"]
+
+    async def test_rest_add_flow_serializer_key_error(self, event_loop):
+        """Test add flow serializer key error exception."""
+        self.napp.controller.loop = event_loop
+        body = {
+            "flows": [
+                {
+                    "priority": 101,
+                    "match": {"in_port": 1},
+                    "actions": [{"what": "1"}],
+                }
+            ],
+        }
+        endpoint = f"{self.base_endpoint}/flows"
+        response = await self.api_client.post(endpoint, json=body)
+        assert response.status_code == 400
+        data = response.json()
+        assert "what" in data["description"]
+
     async def test_rest_del_missing_cookie_mask(self, event_loop):
         """Test del missing cookie_mask."""
         self.napp.controller.loop = event_loop


### PR DESCRIPTION
Closes #146
Closes #91 

### Summary

See updated changelog file

### Local Tests

- Created one EVC, simulated link down and EVC removal:

```
kytos $> 2023-05-11 14:53:20,132 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46284 - "POST /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 400                    
2023-05-11 14:56:05,093 - INFO [kytos.napps.kytos/mef_eline] [evc.py:805:setup_failover_path] (thread_pool_app_4) Failover path for EVC(c96386c0dfe243, epl) was deployed.

2023-05-11 14:56:40,654 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_2) Event handle_link_down Link(Interface('s1-eth4', 4, Switch('00:00:00:00:0
0:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')))
2023-05-11 14:56:40,655 - INFO [kytos.napps.kytos/flow_manager] [main.py:558:handle_flows_install_delete] (thread_pool_app_9) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01,
 command: add, force: False, flows_dict: {'flows': [{'match': {'in_port': 1}, 'cookie': 12306476887179256387, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 
'set_vlan', 'vlan_id': 2}, {'action_type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'epl', 'table_id': 0, 'priority': 10000}]}
2023-05-11 14:56:40,657 - INFO [kytos.napps.kytos/flow_manager] [main.py:558:handle_flows_install_delete] (thread_pool_app_7) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:03,
 command: add, force: False, flows_dict: {'flows': [{'match': {'in_port': 1}, 'cookie': 12306476887179256387, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 
'set_vlan', 'vlan_id': 2}, {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'epl', 'table_id': 0, 'priority': 10000}]}
2023-05-11 14:56:41,169 - INFO [kytos.napps.kytos/mef_eline] [main.py:756:handle_link_down] (thread_pool_app_2) EVC(c96386c0dfe243, epl) redeployed with failover due to link down c8b553
59990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07

```

### End-to-End Tests

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 26%]
tests/test_e2e_11_mef_eline.py ......                                    [ 29%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 32%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 50%]
...                                                                      [ 51%]
tests/test_e2e_14_mef_eline.py x                                         [ 52%]
tests/test_e2e_15_mef_eline.py ..                                        [ 53%]
tests/test_e2e_20_flow_manager.py .....................                  [ 62%]
tests/test_e2e_21_flow_manager.py ...                                    [ 63%]
tests/test_e2e_22_flow_manager.py ...............                        [ 70%]
tests/test_e2e_23_flow_manager.py ..............                         [ 76%]
tests/test_e2e_30_of_lldp.py ....                                        [ 78%]
tests/test_e2e_31_of_lldp.py ...                                         [ 79%]
tests/test_e2e_32_of_lldp.py ...                                         [ 81%]
tests/test_e2e_40_sdntrace.py ...........                                [ 85%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 89%]
tests/test_e2e_50_maintenance.py ........................                [100%]
=============================== warnings summary ===============================
= 205 passed, 6 skipped, 11 xfailed, 5 xpassed, 799 warnings in 10615.20s (2:56:55) =
```
