### PR TITLE
feat: augmented `GET v2/stored_flows` state query filter to support a list of values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 - Added two new fields to the collection ``flows``. ``owner`` has the name of the NApp that created the flow. ``table_group`` is the classification of a flow, for example: ``epl``, ``base`` and ``evpl``.
 - Added new script ``pipeline_related.py`` to add new fields ``owner`` and ``table_group`` to the flows on the collection ``flows`` on MongoDB
 - Added basic validation for ``cookie`` and ``cookie_mask`` when installing or removing flows.
+- Augmented ``GET v2/stored_flows`` state query filter to support a list of values.
 
 Changed
 =======

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -213,15 +213,15 @@ class FlowController:
     def find_flows(
         self,
         dpids: Optional[list[str]] = None,
-        state: Optional[str] = None,
+        states: Optional[list[str]] = None,
         cookie_range: Optional[list[int]] = None,
     ) -> Optional[dict]:
         """Generic method for getting flows with flexible filtering capabilities."""
         query_expression = {}
         if dpids:
             query_expression.update({"switch": {"$in": dpids}})
-        if state:
-            query_expression.update({"state": state})
+        if states:
+            query_expression.update({"state": {"$in": states}})
         if cookie_range:
             query_expression.update(
                 {

--- a/main.py
+++ b/main.py
@@ -506,7 +506,7 @@ class Main(KytosNApp):
         """
         params = request.query_params
         dpids = params.getlist("dpid")
-        state = params.get("state")
+        states = params.getlist("state")
         try:
             cookies = params.getlist("cookie_range")
             cookie_range = [int(v) for v in cookies]
@@ -518,7 +518,7 @@ class Main(KytosNApp):
             msg = "cookie_range only accepts exactly two values."
             raise HTTPException(400, msg)
         flows_collection = dict(
-            self.flow_controller.find_flows(dpids, state, cookie_range)
+            self.flow_controller.find_flows(dpids, states, cookie_range)
         )
         return JSONResponse(flows_collection)
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -151,10 +151,12 @@ paths:
         - name: state
           in: query
           schema:
-            type: string
-          description: State of the flows to retrieve.
+            type: array
+            items:
+              type: string
+          description: List of states to retrieve
           required: false
-          example: "installed"
+          example: ["installed"]
         - name: cookie_range
           in: query
           schema:

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -150,16 +150,16 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
 
     def test_find_flows(self) -> None:
         """Test find_flows."""
-        state = "installed"
+        states = ["installed"]
         cookie_range = [84114963, 84114965]
         assert not list(
             self.flow_controller.find_flows(
-                dpids=[self.dpid], state=state, cookie_range=cookie_range
+                dpids=[self.dpid], states=states, cookie_range=cookie_range
             )
         )
         args = self.flow_controller.db.flows.find.call_args[0]
         assert args[0]["switch"]["$in"] == [self.dpid]
-        assert args[0]["state"] == "installed"
+        assert args[0]["state"]["$in"] == ["installed"]
         assert args[0]["flow.cookie"]["$gte"] == Decimal128(Decimal(cookie_range[0]))
         assert args[0]["flow.cookie"]["$lte"] == Decimal128(Decimal(cookie_range[1]))
 


### PR DESCRIPTION
Closes #152 

### Summary

See updated changelog file

### Local Tests

```
❯ http 'http://0.0.0.0:8181/api/kytos/flow_manager/v2/stored_flows?state=installed' | jq | grep state       
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",

```
```
❯ http 'http://0.0.0.0:8181/api/kytos/flow_manager/v2/stored_flows?state=installed&state=deleted' | jq | grep state
      "state": "installed",
      "state": "installed",
      "state": "deleted",
      "state": "deleted",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "deleted",
      "state": "deleted",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "deleted",
      "state": "deleted",
      "state": "installed",
      "state": "installed",
      "state": "installed",
      "state": "installed",
```

- Also run a `sdntrace_cp` to be extra safe with `mef_eline`:

```
{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 1,
            "time": "2023-05-17 15:23:12.555620",
            "type": "starting",
            "vlan": 400
        },
        {
            "dpid": "00:00:00:00:00:00:00:03",
            "port": 3,
            "time": "2023-05-17 15:23:12.555654",
            "type": "last",
            "vlan": 2,
            "out": {
                "port": 1,
                "vlan": 400
            }
        }
    ]
}
```

### End-to-End Tests

Not needed, the change is backwards compatible.