### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,22 +7,25 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.1.0] - 2023-06-05
+***********************
+
 Added
 =====
 
 - Added support for VLAN with mask. ``dl_vlan`` now also supports a string ``"vlan/mask"``.
 - Added two new fields to the collection ``flows``. ``owner`` has the name of the NApp that created the flow. ``table_group`` is the classification of a flow, for example: ``epl``, ``base`` and ``evpl``.
-- Added new script ``pipeline_related.py`` to add new fields ``owner`` and ``table_group`` to the flows on the collection ``flows`` on MongoDB
 - Added basic validation for ``cookie`` and ``cookie_mask`` when installing or removing flows.
 - Augmented ``GET v2/stored_flows`` state query filter to support a list of values.
 
 Changed
 =======
-- Update endpoint ``GET v2/stored_flows`` to return the flows in descending order by `priority`.
+- Update endpoint ``GET v2/stored_flows`` to return the flows in order by ``priority`` descending and ``updated_at`` ascending.
 
 General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
+- Added new script ``scripts/pipeline_related.py`` to add new fields ``owner`` and ``table_group`` to the flows on the collection ``flows`` on MongoDB. If you are planning to use ``kytos/of_multi_table`` NApp and is upgrading to 2023.1 from 2022.3, you should use this script
 
 
 [2022.3.1] - 2023-02-17

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2022.3.1",
+  "version": "2023.1.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",


### PR DESCRIPTION
### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Not needed (e2e nightly tests are passing)
