### PR TITLE
fix: Added table_id checking when matching flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,10 @@ General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
 
+Fixed
+=====
+- Fixed matching flows when trying to delete flows with specified ``table_id``.
+
 
 [2022.3.1] - 2023-02-17
 ***********************

--- a/tests/unit/test_match_13.py
+++ b/tests/unit/test_match_13.py
@@ -104,6 +104,11 @@ def test_empty_match(to_install, stored, should_match) -> None:
             {"match": {"ipv4_src": "192.168.1.2"}},
             False,
         ),
+        (
+            {"table_id": 1, "cookie": 100},
+            {"table_id": 0, "cookie": 100, "cookie_mask": 18446744073709551615},
+            False,
+        ),
     ],
 )
 def test_match_no_strict_return_false_cases(to_install, stored, should_match):

--- a/tests/unit/test_match_13.py
+++ b/tests/unit/test_match_13.py
@@ -2,7 +2,11 @@
 # pylint: disable=import-error
 import pytest
 from napps.kytos.flow_manager.match import match_flow
-from napps.kytos.flow_manager.v0x04.match import _match_cookie, match13_no_strict
+from napps.kytos.flow_manager.v0x04.match import (
+    _match_cookie,
+    match13_no_strict,
+    _match_table_id,
+)
 
 
 @pytest.mark.parametrize(
@@ -114,6 +118,20 @@ def test_empty_match(to_install, stored, should_match) -> None:
 def test_match_no_strict_return_false_cases(to_install, stored, should_match):
     """Test match_no_strict return False cases that haven't been covered yet."""
     assert bool(match13_no_strict(to_install, stored)) == should_match
+
+
+@pytest.mark.parametrize(
+    "to_install,stored,should_match",
+    [
+        ({"table_id": 1}, {"table_id": 0}, False),
+        ({}, {"table_id": 12}, True),
+        ({"table_id": 255}, {"table_id": 99}, True),
+        ({"table_id": 100}, {"table_id": 100}, True),
+    ],
+)
+def test_match_table_id(to_install, stored, should_match):
+    """Test _match_table_id"""
+    assert bool(_match_table_id(to_install, stored)) == should_match
 
 
 def test_match_func_calls() -> None:

--- a/v0x04/match.py
+++ b/v0x04/match.py
@@ -29,7 +29,9 @@ def match13_no_strict(flow_to_install, stored_flow_dict):
     """
     if not _match_cookie(flow_to_install, stored_flow_dict):
         return False
-
+    if flow_to_install.get("table_id") is not None and \
+       flow_to_install.get("table_id") != stored_flow_dict["table_id"]:
+        return False
     if "match" not in flow_to_install or "match" not in stored_flow_dict:
         return stored_flow_dict
     if not flow_to_install["match"]:

--- a/v0x04/match.py
+++ b/v0x04/match.py
@@ -1,4 +1,5 @@
 """Match for OF 1.3."""
+from pyof.v0x04.controller2switch.table_mod import Table
 
 
 def _match_cookie(flow_to_install, stored_flow_dict):
@@ -26,13 +27,12 @@ def _match_table_id(flow_to_install, stored_flow_dict):
     """Check if table ids are the same or there is a wildcard"""
     if flow_to_install.get("table_id") is None:
         return True
-    if flow_to_install["table_id"] == 0xff:
-        # Wildcard
+    if flow_to_install["table_id"] == Table.OFPTT_ALL.value:
         return True
     if flow_to_install["table_id"] != stored_flow_dict["table_id"]:
         return False
     return True
-    
+
 
 def match13_no_strict(flow_to_install, stored_flow_dict):
     """Match a flow that is either exact or more specific (non-strict) (OF1.3).

--- a/v0x04/match.py
+++ b/v0x04/match.py
@@ -22,6 +22,18 @@ def _match_keys(flow_to_install, stored_flow_dict, flow_to_install_keys):
     return True
 
 
+def _match_table_id(flow_to_install, stored_flow_dict):
+    """Check if table ids are the same or there is a wildcard"""
+    if flow_to_install.get("table_id") is None:
+        return True
+    if flow_to_install["table_id"] == 0xff:
+        # Wildcard
+        return True
+    if flow_to_install["table_id"] != stored_flow_dict["table_id"]:
+        return False
+    return True
+    
+
 def match13_no_strict(flow_to_install, stored_flow_dict):
     """Match a flow that is either exact or more specific (non-strict) (OF1.3).
 
@@ -29,8 +41,7 @@ def match13_no_strict(flow_to_install, stored_flow_dict):
     """
     if not _match_cookie(flow_to_install, stored_flow_dict):
         return False
-    if flow_to_install.get("table_id") is not None and \
-       flow_to_install.get("table_id") != stored_flow_dict["table_id"]:
+    if not _match_table_id(flow_to_install, stored_flow_dict):
         return False
     if "match" not in flow_to_install or "match" not in stored_flow_dict:
         return stored_flow_dict


### PR DESCRIPTION
Closes #155 

### Summary

Flows with different flows were being marked to be deleted. This was because `table_id` was not being checked. Added a condition to compare `table_id` values when necessary.

### Local Tests

Installed flows through POST `http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01`:
```
{
    "force": false,
    "flows": [
        {
            "priority": 40000,
            "cookie": 100,
            "table_id": 0,
            "instructions": [
                {
                    "instruction_type": "goto_table",
                    "table_id": 1
                }
            ]
        },
        {
            "priority": 40000,
            "cookie": 100,
            "table_id": 1,
            "instructions": [
                {
                    "instruction_type": "goto_table",
                    "table_id": 2
                }
            ]
        }
    ]
}
```
Deleteting with DELETE `http://localhost:8181/api/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01`, should only delete 1 flow:
```
{
    "force": false,
    "flows": [
        {
            "priority": 40000,
            "table_id": 0,
            "cookie": 100,
            "cookie_mask": 18446744073709551615
        }
    ]
}
```
