### PR TITLE
chore: added scripts/drop_compound_index.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
 General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
+- ``scripts/drop_compound_index.py`` can be used to drop a compound index that has changed.
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Changed
 General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
-- ``scripts/drop_compound_index.py`` can be used to drop a compound index that has changed.
+- ``scripts/drop_compound_index.py`` can be used to drop a compound index that has changed. If you tried to upgrade to ``2022.3.2`` before and it ended up creating ``'flow.priority_1'`` index, then you also want to delete it by running ``CMD=drop_index INDEX_NAME=flow.priority_1 python3 drop_compound_index.py``
 
 Fixed
 =====

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -46,15 +46,15 @@ class FlowController:
         index_tuples = [
             ("flows", [("flow_id", pymongo.ASCENDING)], {"unique": True}),
             ("flows", [("flow.cookie", pymongo.ASCENDING)], {}),
-            ("flows", [("flow.priority", pymongo.ASCENDING)], {}),
+            ("flows", [("flow.priority", pymongo.DESCENDING)], {}),
             ("flows", [("state", pymongo.ASCENDING)], {}),
             (
                 "flows",
                 [
                     ("switch", pymongo.ASCENDING),
                     ("flow.cookie", pymongo.ASCENDING),
-                    ("flow.priority", pymongo.ASCENDING),
                     ("state", pymongo.ASCENDING),
+                    ("flow.priority", pymongo.DESCENDING),
                     ("inserted_at", pymongo.ASCENDING),
                     ("updated_at", pymongo.ASCENDING),
                 ],

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,3 +62,11 @@ Run the script to upgrade all flows from `mef_eline`, `of_lldp` and `coloring` w
 ```
 python3 pipeline_related.py
 ```
+
+### Drop compound index
+
+On version `2023.1`, this `flows` compound index `switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1` has changed. If you're upgrading to `2023.1` froma previous version, you should run the `drop_compound_index.py` script to drop it:
+
+```
+CMD=drop_index python3 drop_compound_index.py
+```

--- a/scripts/drop_compound_index.py
+++ b/scripts/drop_compound_index.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import sys
+import os
+import pymongo
+
+from napps.kytos.flow_manager.controllers import FlowController
+
+
+flow_controller = FlowController()
+
+
+def drop_index(index_name=None, flow_controller=flow_controller) -> dict:
+    """drop_index."""
+    index_name = index_name or os.environ.get(
+        "INDEX_NAME", "switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1"
+    )
+    return flow_controller.db.flows.drop_index(index_name)
+
+
+if __name__ == "__main__":
+    cmds = {
+        "drop_index": drop_index,
+    }
+    try:
+        cmd = os.environ["CMD"]
+    except KeyError:
+        print("Please set the 'CMD' env var.")
+        sys.exit(1)
+    try:
+        for command in cmd.split(","):
+            print(cmds[command]())
+    except KeyError as e:
+        print(
+            f"Unknown cmd: {str(e)}. 'CMD' env var has to be one of these {list(cmds.keys())}."
+        )
+        sys.exit(1)
+    except pymongo.errors.PyMongoError as e:
+        print(f"pymongo error: {str(e)}")
+        sys.exit(1)

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -35,15 +35,15 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         expected_indexes = [
             ("flows", [("flow_id", 1)]),
             ("flows", [("flow.cookie", 1)]),
-            ("flows", [("flow.priority", 1)]),
+            ("flows", [("flow.priority", -1)]),
             ("flows", [("state", 1)]),
             (
                 "flows",
                 [
                     ("switch", 1),
                     ("flow.cookie", 1),
-                    ("flow.priority", 1),
                     ("state", 1),
+                    ("flow.priority", -1),
                     ("inserted_at", 1),
                     ("updated_at", 1),
                 ],


### PR DESCRIPTION
Closes #160 

I'll send a backport to `2022.3.2` shortly

### Summary

See updated changelog for more information

### Local Tests

- On version `2022.3.2` I ran this script:

```
❯ CMD=drop_index python3 drop_compound_index.py      
None
```

If you try to run again, it'll error out as expect since the index `switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1` doesn't exist anymore:

```
❯ CMD=drop_index python3 drop_compound_index.py
pymongo error: index not found with name [switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1], full error: {'ok': 0.0, 'errmsg': 'index not found with name [switch_1_flow.cookie_1
_state_1_inserted_at_1_updated_at_1]', 'code': 27, 'codeName': 'IndexNotFound', '$clusterTime': {'clusterTime': Timestamp(1691420918, 2), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00
\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1691420918, 2)}
```

- On `master` (future `2023.1`) I ran this script as well:

```
❯ CMD=drop_index python3 drop_compound_index.py      
None
```

```
rs0 [direct: primary] napps> db.flows.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  {
    v: 2,
    key: { flow_id: 1 },
    name: 'flow_id_1',
    background: true,
    unique: true
  },
  {
    v: 2,
    key: { 'flow.cookie': 1 },
    name: 'flow.cookie_1',
    background: true
  },
  {
    v: 2,
    key: { 'flow.priority': -1 },
    name: 'flow.priority_-1',
    background: true
  },
  { v: 2, key: { state: 1 }, name: 'state_1', background: true },
  {
    v: 2,
    key: {
      switch: 1,
      'flow.cookie': 1,
      state: 1,
      'flow.priority': -1,
      inserted_at: 1,
      updated_at: 1
    },
    name: 'switch_1_flow.cookie_1_state_1_flow.priority_-1_inserted_at_1_updated_at_1',
    background: true
  }
]
rs0 [direct: primary] napps> 
```

```
rs0 [direct: primary] napps> db.flows.countDocuments()
1009
```

During these local tests I always had 1000+ flows installed, no other issues were observed including during `kytosd` restarts


### End-to-End Tests

I'll dispatch an execution, but I don't expect surprises.