### PR TITLE
chore: release 2022.3.3: added scripts/drop_compound_index.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.3] - 2023-08-07
+***********************
+
+General Information
+===================
+- ``scripts/drop_compound_index.py`` can be used to drop a compound index that has changed. If you tried to upgrade to ``2022.3.2`` before and it ended up creating ``'flow.priority_1'`` index, then you also want to delete it by running ``CMD=drop_index INDEX_NAME=flow.priority_1 python3 drop_compound_index.py``
+
 [2022.3.2] - 2023-07-20
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -46,15 +46,15 @@ class FlowController:
         index_tuples = [
             ("flows", [("flow_id", pymongo.ASCENDING)], {"unique": True}),
             ("flows", [("flow.cookie", pymongo.ASCENDING)], {}),
-            ("flows", [("flow.priority", pymongo.ASCENDING)], {}),
+            ("flows", [("flow.priority", pymongo.DESCENDING)], {}),
             ("flows", [("state", pymongo.ASCENDING)], {}),
             (
                 "flows",
                 [
                     ("switch", pymongo.ASCENDING),
                     ("flow.cookie", pymongo.ASCENDING),
-                    ("flow.priority", pymongo.ASCENDING),
                     ("state", pymongo.ASCENDING),
+                    ("flow.priority", pymongo.DESCENDING),
                     ("inserted_at", pymongo.ASCENDING),
                     ("updated_at", pymongo.ASCENDING),
                 ],

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2022.3.2",
+  "version": "2022.3.3",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,7 +65,7 @@ python3 pipeline_related.py
 
 ### Drop compound index
 
-On version `2023.1`, this `flows` compound index `switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1` has changed. If you're upgrading to `2023.1` froma previous version, you should run the `drop_compound_index.py` script to drop it:
+On version `2023.1`, this `flows` compound index `switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1` has changed. If you're upgrading to `2023.1` from a previous version, you should run the `drop_compound_index.py` script to drop it:
 
 ```
 CMD=drop_index python3 drop_compound_index.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,3 +49,24 @@ And then, to insert (or update) the flows:
 ```
 CMD=insert_flows python3 scripts/storehouse_to_mongo.py
 ```
+
+### Add `owner` and `table_group` fields to `flows` collections
+
+### Pre-requisites
+Same requisites as above
+
+### How to use
+
+Run the script to upgrade all flows from `mef_eline`, `of_lldp` and `coloring` with new fields `owner` and `table_group`
+
+```
+python3 pipeline_related.py
+```
+
+### Drop compound index
+
+On version `2023.1`, this `flows` compound index `switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1` has changed. If you're upgrading to `2023.1` froma previous version, you should run the `drop_compound_index.py` script to drop it:
+
+```
+CMD=drop_index python3 drop_compound_index.py
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,19 +50,6 @@ And then, to insert (or update) the flows:
 CMD=insert_flows python3 scripts/storehouse_to_mongo.py
 ```
 
-### Add `owner` and `table_group` fields to `flows` collections
-
-### Pre-requisites
-Same requisites as above
-
-### How to use
-
-Run the script to upgrade all flows from `mef_eline`, `of_lldp` and `coloring` with new fields `owner` and `table_group`
-
-```
-python3 pipeline_related.py
-```
-
 ### Drop compound index
 
 On version `2023.1`, this `flows` compound index `switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1` has changed. If you're upgrading to `2023.1` from a previous version, you should run the `drop_compound_index.py` script to drop it:

--- a/scripts/drop_compound_index.py
+++ b/scripts/drop_compound_index.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import sys
+import os
+import pymongo
+
+from napps.kytos.flow_manager.controllers import FlowController
+
+
+flow_controller = FlowController()
+
+
+def drop_index(index_name=None, flow_controller=flow_controller) -> dict:
+    """drop_index."""
+    index_name = index_name or os.environ.get(
+        "INDEX_NAME", "switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1"
+    )
+    return flow_controller.db.flows.drop_index(index_name)
+
+
+if __name__ == "__main__":
+    cmds = {
+        "drop_index": drop_index,
+    }
+    try:
+        cmd = os.environ["CMD"]
+    except KeyError:
+        print("Please set the 'CMD' env var.")
+        sys.exit(1)
+    try:
+        for command in cmd.split(","):
+            print(cmds[command]())
+    except KeyError as e:
+        print(
+            f"Unknown cmd: {str(e)}. 'CMD' env var has to be one of these {list(cmds.keys())}."
+        )
+        sys.exit(1)
+    except pymongo.errors.PyMongoError as e:
+        print(f"pymongo error: {str(e)}")
+        sys.exit(1)

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -35,15 +35,15 @@ class TestFlowController(TestCase):  # pylint: disable=too-many-public-methods
         expected_indexes = [
             ("flows", [("flow_id", 1)]),
             ("flows", [("flow.cookie", 1)]),
-            ("flows", [("flow.priority", 1)]),
+            ("flows", [("flow.priority", -1)]),
             ("flows", [("state", 1)]),
             (
                 "flows",
                 [
                     ("switch", 1),
                     ("flow.cookie", 1),
-                    ("flow.priority", 1),
                     ("state", 1),
+                    ("flow.priority", -1),
                     ("inserted_at", 1),
                     ("updated_at", 1),
                 ],


### PR DESCRIPTION
### Summary

Backported from PR #162 

### Local Tests

Upgraded from `2022.3.1` to `2022.3.3`:

```

rs0 [direct: primary] napps> db.flows.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  {
    v: 2,
    key: { flow_id: 1 },
    name: 'flow_id_1',
    background: true,
    unique: true
  },
  {
    v: 2,
    key: { 'flow.cookie': 1 },
    name: 'flow.cookie_1',
    background: true
  },
  { v: 2, key: { state: 1 }, name: 'state_1', background: true },
  {
    v: 2,
    key: {
      switch: 1,
      'flow.cookie': 1,
      state: 1,
      inserted_at: 1,
      updated_at: 1
    },
    name: 'switch_1_flow.cookie_1_state_1_inserted_at_1_updated_at_1',
    background: true
  }
]
rs0 [direct: primary] napps> db.flows.countDocuments()
1003

```

- Ran the script, and confirmed the index deletion:

```
❯ CMD=drop_index python3 drop_compound_index.py
None
```

```
rs0 [direct: primary] napps> db.flows.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  {
    v: 2,
    key: { flow_id: 1 },
    name: 'flow_id_1',
    background: true,
    unique: true
  },
  {
    v: 2,
    key: { 'flow.cookie': 1 },
    name: 'flow.cookie_1',
    background: true
  },
  { v: 2, key: { state: 1 }, name: 'state_1', background: true }
]
rs0 [direct: primary] napps> 
```

- After that, started `kytosd` again, and the new priority indexes were created as expected:

```
2023-08-07 13:14:40,734 - INFO [kytos.napps.kytos/flow_manager] (MainThread) Created DB index [('flow.priority', -1)], collection: flows)
2023-08-07 13:14:40,788 - INFO [kytos.napps.kytos/flow_manager] (MainThread) Created DB index [('switch', 1), ('flow.cookie', 1), ('state', 1), ('flow.priority', -1), ('inserted_at', 1
), ('updated_at', 1)], collection: flows)
```

```
rs0 [direct: primary] napps> db.flows.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  {
    v: 2,
    key: { flow_id: 1 },
    name: 'flow_id_1',
    background: true,
    unique: true
  },
  {
    v: 2,
    key: { 'flow.cookie': 1 },
    name: 'flow.cookie_1',
    background: true
  },
  { v: 2, key: { state: 1 }, name: 'state_1', background: true },
  {
    v: 2,
    key: { 'flow.priority': -1 },
    name: 'flow.priority_-1',
    background: true
  },
  {
    v: 2,
    key: {
      switch: 1,
      'flow.cookie': 1,
      state: 1,
      'flow.priority': -1,
      inserted_at: 1,
      updated_at: 1
    },
    name: 'switch_1_flow.cookie_1_state_1_flow.priority_-1_inserted_at_1_updated_at_1',
    background: true
  }
]
rs0 [direct: primary] napps> db.flows.countDocuments()
1003

```

### Heads up

If you tried to upgrade to `2022.3.2` before and it ended up creating `'flow.priority_1'` index, then you also want to delete it by running:

```
CMD=drop_index INDEX_NAME=flow.priority_1 python3 drop_compound_index.py
```

### End-to-End Tests

A few tests failed, but they are related to https://github.com/kytos-ng/kytos-end-to-end-tests/issues/255:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.2.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 239 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 25%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 48%]
...                                                                      [ 49%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 72%]
tests/test_e2e_30_of_lldp.py ....                                        [ 74%]
tests/test_e2e_31_of_lldp.py ...                                         [ 75%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py ..RRFRRFRRF......                          [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 97%]
tests/test_e2e_70_kytos_stats.py .......                                 [100%]
=================================== FAILURES ===================================
RERUN tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_020_run_sdntrace_fail_missing_flow
RERUN tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_020_run_sdntrace_fail_missing_flow
RERUN tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_030_run_sdntrace_for_stored_flows
RERUN tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_030_run_sdntrace_for_stored_flows
RERUN tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_040_run_sdntrace_no_action
RERUN tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_040_run_sdntrace_no_action
```