### PR TITLE
feat: updated v2/stored_flows cookie_range to accept an even list of ranges

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 - Added new script ``pipeline_related.py`` to add new fields ``owner`` and ``table_group`` to the flows on the collection ``flows`` on MongoDB
 - Added basic validation for ``cookie`` and ``cookie_mask`` when installing or removing flows.
 - Augmented ``GET v2/stored_flows`` state query filter to support a list of values.
+- Augmented ``GET v2/stored_flows`` ``cookie_range`` to accept an even list of ranges
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ from .utils import (
     cast_fields,
     get_min_wait_diff,
     is_ignored,
+    map_cookie_list_as_tuples,
     merge_cookie_ranges,
     validate_cookies_and_masks,
 )
@@ -514,11 +515,14 @@ class Main(KytosNApp):
             raise HTTPException(
                 400, detail=f"cookie_range {cookies} couldn't be cast as an int"
             )
-        if not (len(cookie_range) == 2 or len(cookie_range) == 0):
-            msg = "cookie_range only accepts exactly two values."
-            raise HTTPException(400, msg)
+        try:
+            cookie_ranges = map_cookie_list_as_tuples(cookie_range)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc))
+
+        cookie_ranges = merge_cookie_ranges(cookie_ranges)
         flows_collection = dict(
-            self.flow_controller.find_flows(dpids, states, cookie_range)
+            self.flow_controller.find_flows(dpids, states, cookie_ranges)
         )
         return JSONResponse(flows_collection)
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -163,7 +163,7 @@ paths:
             type: array
             items:
               type: integer
-          description: Range of cookies
+          description: Inclusive range of cookies. The length of the list must be even, for example, [1, 2, 5, 6], would include from 1 to 2 and from 5 to 6.
           required: false
           example: [84114963, 84114965]
       responses:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -202,7 +202,7 @@ class TestMain:
         )
         response = await self.api_client.get(endpoint)
         assert response.status_code == 400
-        assert "exactly two values" in response.json()["description"]
+        assert "Expected cookies length to be even" in response.json()["description"]
 
     async def test_list_flows_fail_case(self):
         """Test the failure case to recover all flows from a switch by dpid.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,6 +12,7 @@ from napps.kytos.flow_manager.utils import (
     build_cookie_range_tuple,
     build_flow_mod_from_command,
     get_min_wait_diff,
+    map_cookie_list_as_tuples,
     merge_cookie_ranges,
     validate_cookies_add,
     validate_cookies_del,
@@ -118,6 +119,31 @@ def test_build_cookie_range_tuple(cookie, cookie_mask, expected) -> None:
 def test_merge_cookie_ranges(cookie_ranges, merged) -> None:
     """Test merge_cookie_ranges."""
     assert merge_cookie_ranges(cookie_ranges) == merged
+
+
+@pytest.mark.parametrize(
+    "cookies,expected",
+    [
+        (
+            [1, 2, 4, 5],
+            [(1, 2), (4, 5)],
+        ),
+        (
+            [],
+            [],
+        ),
+    ],
+)
+def test_map_cookie_list_as_tuples(cookies, expected) -> None:
+    """Test map_cookie_list_as_tuples."""
+    assert map_cookie_list_as_tuples(cookies) == expected
+
+
+def test_map_cookie_list_as_tuples_fail() -> None:
+    """Test map_cookie_list_as_tuples."""
+    with pytest.raises(ValueError) as exc:
+        map_cookie_list_as_tuples([1, 2, 3])
+    assert "to be even" in str(exc)
 
 
 @pytest.mark.parametrize(

--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,7 @@ def build_cookie_range_tuple(cookie: int, cookie_mask: int) -> tuple[int, int]:
 
 
 def map_cookie_list_as_tuples(cookies: list[int]) -> list[tuple[int, int]]:
-    """Mape cookie list as tuples."""
+    """Map cookie list as tuples."""
     if len(cookies) % 2 == 1:
         raise ValueError(f"Expected cookies length to be even, got length {cookies}")
     stack = []

--- a/utils.py
+++ b/utils.py
@@ -19,6 +19,16 @@ def build_cookie_range_tuple(cookie: int, cookie_mask: int) -> tuple[int, int]:
     return cookie & cookie_mask, cookie_high
 
 
+def map_cookie_list_as_tuples(cookies: list[int]) -> list[tuple[int, int]]:
+    """Mape cookie list as tuples."""
+    if len(cookies) % 2 == 1:
+        raise ValueError(f"Expected cookies length to be even, got length {cookies}")
+    stack = []
+    for i in range(1, len(cookies), 2):
+        stack.append((cookies[i - 1], cookies[i]))
+    return stack
+
+
 def merge_cookie_ranges(cookie_ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
     """Merge overlaping cookie ranges to simplify DB "$or" operator query complexity."""
     if len(cookie_ranges) <= 1:


### PR DESCRIPTION
Closes #165 

### Summary

See updated changelog file

### Local Tests

Query latency reasonable as expected on APM:

![20230808_163250](https://github.com/kytos-ng/flow_manager/assets/1010796/26c30901-9cf0-40d4-b39e-8c606ca0f95c)

Also, sent a few requests exploring the parameters, worked as expected:

```
❯ http 'http://0.0.0.0:8181/api/kytos/flow_manager/v2/stored_flows?cookie_range=1&cookie_range=2&cookie_range=10&cookie_range=13'
HTTP/1.1 200 OK
content-length: 2489
content-type: application/json
date: Tue, 08 Aug 2023 19:25:46 GMT
server: uvicorn

{
    "00:00:00:00:00:00:00:01": [
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 13,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 13,
                    "in_port": 1
                },
                "priority": 13,
                "table_group": "base",
                "table_id": 0
            },
            "flow_id": "5b0cf6c243d8f318051d758a9acfd4db",
            "id": "f5de0eb1c875b49837ecd58b687c72c9",
            "inserted_at": "2023-08-08T19:23:35.052000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-08-08T19:23:35.313000"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 12,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 12,
                    "in_port": 1
                },
                "priority": 12,
                "table_group": "base",
                "table_id": 0
            },
            "flow_id": "fc605f52cf93d656a6c9c23854b82c69",
            "id": "07531808aae42b73cd2cbd7fb616038e",
            "inserted_at": "2023-08-08T19:23:35.052000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-08-08T19:23:35.313000"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 11,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 11,
                    "in_port": 1
                },
                "priority": 11,
                "table_group": "base",
                "table_id": 0
            },
            "flow_id": "1c0d0d75c622942bc9bcca335bf885e8",
            "id": "fe8e967ef16708cc2beebd18182a5a36",
            "inserted_at": "2023-08-08T19:23:35.052000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-08-08T19:23:35.313000"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 10,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 10,
                    "in_port": 1
                },
                "priority": 10,
                "table_group": "base",
                "table_id": 0
            },
            "flow_id": "b49ff1fb9d3ce1a31982741358bf5461",
            "id": "4d8734bc8cf5b9153be761f471d63451",
            "inserted_at": "2023-08-08T19:23:35.052000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-08-08T19:23:35.313000"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 2,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 2,
                    "in_port": 1
                },
                "priority": 2,
                "table_group": "base",
                "table_id": 0
            },
            "flow_id": "268dc268be7e02ed144e18b91e12a274",
            "id": "7a21877fcd5da593936a41de44b9e330",
            "inserted_at": "2023-08-08T19:23:35.052000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-08-08T19:23:35.313000"
        },
        {
            "flow": {
                "actions": [
                    {
                        "action_type": "output",
                        "port": 2
                    }
                ],
                "cookie": 1,
                "hard_timeout": 0,
                "idle_timeout": 0,
                "match": {
                    "dl_vlan": 1,
                    "in_port": 1
                },
                "priority": 1,
                "table_group": "base",
                "table_id": 0
            },
            "flow_id": "0869ef60ff80f1004a50d9f9ac0e3907",
            "id": "fd1509d23c9a43fb9e7151094a0b97f4",
            "inserted_at": "2023-08-08T19:23:35.052000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-08-08T19:23:35.313000"
        }
    ]
}
```

### End-to-End Tests

I'll dispatch an execution, I don't expect surprises though
