### PR TITLE
Added validator for `actions` and `instructions`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 Changed
 =======
 - Update endpoint ``GET v2/stored_flows`` to return the flows in descending order by `priority`.
+- When creating a flow, ``actions`` and ``instruction`` are not allowed to be present at the same time.
 
 General Information
 ===================

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 from bson.decimal128 import Decimal128
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 
 class FlowEntryState(Enum):
@@ -127,6 +127,15 @@ class FlowSubDoc(BaseModel):
         if isinstance(v, (int, str)):
             return Decimal128(Decimal(v))
         return v
+
+    @root_validator()
+    def validate_actions_intructions(cls, values) -> dict:
+        """Validate that actions and intructions are mutually exclusive"""
+        if values.get("actions") is not None and values.get("instructions") is not None:
+            raise ValueError(
+                'Cannot have both "actions" and "instructions" at the same time'
+            )
+        return values
 
 
 class FlowDoc(DocumentBaseModel):

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from napps.kytos.of_core.flow import FlowFactory
 from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_core.settings import STATS_INTERVAL
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from pydantic import ValidationError
 from pyof.foundation.exceptions import PackException
 from pyof.v0x04.asynchronous.error_msg import ErrorType
 from pyof.v0x04.common.header import Type
@@ -23,6 +24,7 @@ from kytos.core.rest_api import (
     JSONResponse,
     Request,
     content_type_json_or_415,
+    error_msg,
     get_json_or_400,
 )
 
@@ -571,6 +573,9 @@ class Main(KytosNApp):
             )
         except SwitchNotConnectedError as error:
             self._send_napp_event(switch, error.flow, "error")
+        except ValidationError as error:
+            msg = error_msg(error.errors())
+            log.error(f"Error with validation: {error}")
 
     @rest("v2/flows", methods=["POST"])
     @rest("v2/flows/{dpid}", methods=["POST"])
@@ -653,6 +658,9 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=str(error))
         except FlowSerializerError as error:
             raise HTTPException(400, detail=str(error))
+        except ValidationError as error:
+            msg = error_msg(error.errors())
+            raise HTTPException(400, detail=msg) from error
 
     def _install_flows(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ add-ignore = D105
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments,too-many-public-methods,unnecessary-pass,import-error,relative-beyond-top-level,attribute-defined-outside-init --ignored-modules=napps.kytos.topology
+pylint args = --disable=no-name-in-module,too-many-locals,too-few-public-methods,too-many-instance-attributes,no-else-return,dangerous-default-value,duplicate-code,raise-missing-from,too-many-arguments,too-many-public-methods,unnecessary-pass,import-error,relative-beyond-top-level,attribute-defined-outside-init --ignored-modules=napps.kytos.topology
 linters=pylint,pycodestyle,isort,black
 
 [flake8]

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -1,6 +1,7 @@
 """TestDbModels."""
-
+import pytest
 from napps.kytos.flow_manager.db.models import FlowDoc
+from pydantic import ValidationError
 
 
 class TestDbModels:
@@ -53,3 +54,23 @@ class TestDbModels:
         }
         flow_doc = FlowDoc(**data)
         assert flow_doc
+
+    def test_flow_validation_error(self) -> None:
+        """Test a flow with intructions and actions fields"""
+        flow_dict = {
+            "instructions": [
+                {
+                    "instruction_type": "apply_actions",
+                    "actions": [{"action_type": "output", "port": 10}],
+                }
+            ],
+            "actions": [{"action_type": "output", "port": 31}],
+        }
+        data = {
+            "switch": "00:00:00:00:00:00:00:02",
+            "flow_id": "1",
+            "id": "0",
+            "flow": flow_dict,
+        }
+        with pytest.raises(ValidationError):
+            FlowDoc(**data)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,7 +13,7 @@ from napps.kytos.of_core.v0x04.flow import Flow as Flow04
 from pyof.v0x04.asynchronous.error_msg import ErrorType
 from pyof.v0x04.common.header import Type
 from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
-
+from pydantic import BaseModel, ValidationError
 from kytos.core.helpers import now
 from kytos.lib.helpers import (
     get_connection_mock,
@@ -322,6 +322,33 @@ class TestMain:
         assert responses[1].status_code == 404
 
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    async def test_rest_add_error(self, mock_install_flows, event_loop):
+        """Test rest endpoint with ValidationError"""
+        self.napp.controller.loop = event_loop
+        switch = MagicMock()
+        switch.is_enabled = lambda: True
+        self.napp.controller.get_switch_by_dpid = lambda id: switch
+        dpid = "00:00:00:00:00:00:00:02"
+        data = {
+            "flows": [
+                {
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "output", "port": 10}],
+                        }
+                    ],
+                    "actions": [{"action_type": "output", "port": 31}],
+                }
+            ]
+        }
+        mock_install_flows.side_effect = ValidationError("", BaseModel)
+        response = await self.api_client.post(
+            f"{self.base_endpoint}/flows/{dpid}", json=data
+        )
+        assert response.status_code == 400
+
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
     async def test_rest_flow_mod_add_switch_not_connected(
         self, mock_install_flows, event_loop
     ):
@@ -475,6 +502,35 @@ class TestMain:
             "add", mock_flow_dict, [switch], reraise_conn=True
         )
         mock_log.info.assert_called()
+
+    @patch("napps.kytos.flow_manager.main.log")
+    @patch("napps.kytos.flow_manager.main.Main._install_flows")
+    def test_event_add_flow_error(self, mock_install_flows, mock_log):
+        """Test event of adding a flow with ValidationError"""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid)
+        self.napp.controller.switches = {dpid: switch}
+        mock_flow_dict = {
+            "flows": [
+                {
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "output", "port": 10}],
+                        }
+                    ],
+                    "actions": [{"action_type": "output", "port": 31}],
+                }
+            ]
+        }
+        event = get_kytos_event_mock(
+            name="kytos.flow_manager.flows.install",
+            content={"dpid": dpid, "flow_dict": mock_flow_dict},
+        )
+        mock_install_flows.side_effect = ValidationError("", BaseModel)
+        self.napp.handle_flows_install_delete(event)
+        mock_log.error.assert_called()
+        assert mock_log.error.call_count == 1
 
     @patch("napps.kytos.flow_manager.main.log")
     @patch("napps.kytos.flow_manager.main.Main._install_flows")


### PR DESCRIPTION
Closes #159 

### Summary
When adding a flow, `actions` and `instructions` should not be present at the same time.

### Local Tests
Created requests with `actions` and `instructions` in the same flow.
Added uni tests