### PR TITLE
feat: added support for batching FlowMods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,12 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
 - Augmented ``GET v2/stored_flows`` ``cookie_range`` to accept an even list of ranges
+- Augmented ``POST v2/flows`` to support batching flows, ``batch_size`` and ``batch_interval`` were introduced. Check out the OpenAPI documentation.
+- Augmented ``kytos.flow_manager.flows.(install|delete)`` event to accept ``batch_size`` and ``batch_interval`` in the ``flow_dict`` payload to support batching.
+
 
 [2023.1.0] - 2023-06-05
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ Subscribed
 - ``kytos/of_core.v0x04.messages.in.ofpt_barrier_reply``
 - ``kytos/core.openflow.connection.error``
 - ``.*.of_core.*.ofpt_error``
+- ``kytos.flow_manager.send_flows``
 
 Generated
 ---------

--- a/main.py
+++ b/main.py
@@ -565,15 +565,15 @@ class Main(KytosNApp):
             return
 
         try:
-            force = bool(flow_dict.get("force", False))
-            batch_size = int(flow_dict.get("batch_size", 0))
-            batch_interval = int(flow_dict.get("batch_interval", 0))
+            force = bool(event.content.get("force", False))
+            batch_size = int(event.content.get("batch_size", 0))
+            batch_interval = int(event.content.get("batch_interval", 0))
         except (ValueError, TypeError):
             log.error(
                 "Invalid 'force', 'batch_size' or 'batch_interval' value/type. "
-                f"force: {flow_dict.get('force', False)}, "
-                f"batch_size: {flow_dict.get('batch_size', 0)}, "
-                f"batch_interval: {flow_dict.get('batch_interval', 0)}, "
+                f"force: {event.content.get('force', False)}, "
+                f"batch_size: {event.content.get('batch_size', 0)}, "
+                f"batch_interval: {event.content.get('batch_interval', 0)}, "
             )
 
         switch = self.controller.get_switch_by_dpid(dpid)

--- a/openapi.yml
+++ b/openapi.yml
@@ -343,6 +343,16 @@ components:
           type: boolean
           description: The force option is for ignoring switch connection errors, and delegating the flows to be automatically sent later on via consistency check.
           default: false
+        batch_size:
+          type: integer
+          description: This is for batching, represents how many flows to send per iteration, every batch_interval seconds. If this value is zero it will send all at once. If you are sending many flows you probably want to use batching to potentially avoid overwhelming switches. Also, if the force option is true, then it will not block the request.
+          minimum: 0
+          default: 0
+        batch_interval:
+          type: integer
+          description: The interval to wait for in seconds when sending a batch of flows.
+          minimum: 0
+          default: 0
     FlowDoc:
       type: object
       properties:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -499,7 +499,12 @@ class TestMain:
         )
         self.napp.handle_flows_install_delete(event)
         mock_install_flows.assert_called_with(
-            "add", mock_flow_dict, [switch], reraise_conn=True
+            "add",
+            mock_flow_dict,
+            [switch],
+            reraise_conn=True,
+            batch_size=0,
+            batch_interval=0,
         )
         mock_flows_log.assert_called()
 
@@ -545,7 +550,12 @@ class TestMain:
         )
         self.napp.handle_flows_install_delete(event)
         mock_install_flows.assert_called_with(
-            "delete", mock_flow_dict, [switch], reraise_conn=True
+            "delete",
+            mock_flow_dict,
+            [switch],
+            reraise_conn=True,
+            batch_size=0,
+            batch_interval=0,
         )
         mock_flows_log.assert_called()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -654,9 +654,9 @@ class TestMain:
         self.napp.controller.buffers.msg_out.put = mock_buffers_put
         self.napp._send_flow_mod = mock_send_flow_mod()
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
-        n = 5
-        flow_mods = [MagicMock() for _ in range(n)]
-        flows = [MagicMock() for _ in range(n)]
+        n_flows = 5
+        flow_mods = [MagicMock() for _ in range(n_flows)]
+        flows = [MagicMock() for _ in range(n_flows)]
         batch_size = 2
         batch_interval = 1
 
@@ -670,9 +670,9 @@ class TestMain:
 
         mock_buffers_put.assert_called()
         log.info.assert_called()
-        assert time.sleep.call_count == math.ceil(n / batch_size) - 1
+        assert time.sleep.call_count == math.ceil(n_flows / batch_size) - 1
         time.sleep.assert_called_with(batch_interval)
-        assert flows_log.call_count == math.ceil(n / batch_size)
+        assert flows_log.call_count == math.ceil(n_flows / batch_size)
         assert self.napp._send_flow_mod.call_count == len(flow_mods)
 
     @patch("kytos.core.buffers.KytosEventBuffer.put")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -261,6 +261,6 @@ class TestUtils(TestCase):
     @patch("napps.kytos.flow_manager.utils.log")
     def test_flows_to_log_info(self, mock_log):
         """Test flows_to_log_info"""
-        flows = {"flows": list(range(500))}
-        flows_to_log_info("", flows)
+        flows = list(range(500))
+        flows_to_log_info("", flows, maximum=200)
         assert mock_log.info.call_count == 3

--- a/utils.py
+++ b/utils.py
@@ -187,13 +187,12 @@ def validate_cookies_del(flows: list[dict]) -> None:
             )
 
 
-def flows_to_log_info(message: str, flow_dict: dict[str, list]) -> None:
+def flows_to_log_info(message: str, flows: list[dict], maximum=200) -> None:
     """Log flows, maximun flows in a log is 200"""
-    maximun = 200
-    flows_n = len(flow_dict["flows"])
-    i, j = 0, maximun
-    while flow_dict["flows"][i:j]:
+    flows_n = len(flows)
+    i, j = 0, maximum
+    while flows[i:j]:
         log.info(
-            f"{message} flows[{i}, {(j if j < flows_n else flows_n)}]: {flow_dict['flows'][i:j]}"
+            f"{message} flows[{i}, {(j if j < flows_n else flows_n)}]: {flows[i:j]}"
         )
-        i, j = i + maximun, j + maximun
+        i, j = i + maximum, j + maximum


### PR DESCRIPTION
Closes #171 

### Summary

- See updated changelog file 
- Version of the API wasn't bumped since it'll need to be bumped in the future for the rest of validations on v3, so we're saving a bit of refactoring on endpoint parametrization, since it's breaking compatibility it's a reasonable tradeoff for now.

### Local Tests

- Made a request with `force: false` with batching, it didn't block the request

```
2023-08-31 16:42:52,272 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, batch_size: 2
, batch_interval: 5, flows[0, 3]: [{'priority': 4000, 'cookie': 100, 'match': {'in_port': 1, 'dl_vlan': 1}, 'actions': [{'action_type': 'output', 'port': 2}]}, {'priority': 4000, 'cook
ie': 100, 'match': {'in_port': 1, 'dl_vlan': 2}, 'actions': [{'action_type': 'output', 'port': 2}]}, {'priority': 4000, 'cookie': 100, 'match': {'in_port': 1, 'dl_vlan': 3}, 'actions':
 [{'action_type': 'output', 'port': 2}]}]
2023-08-31 16:42:52,281 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Sending FlowMods slice[0: 2], iteration: 0, flows[0, 2]: [{'switch': '00:00:00:00:00:00:00:01', 't
able_id': 0, 'match': {'in_port': 1, 'dl_vlan': 1}, 'priority': 4000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 100, 'id': '2e371cca3dcfe383a5058c4410920c1e', 'stats': {}, 'cooki
e_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}, {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {
'in_port': 1, 'dl_vlan': 2}, 'priority': 4000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 100, 'id': '8f4ebd12d31dba67b36dadfad7ba2c84', 'stats': {}, 'cookie_mask': 0, 'instructio
ns': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}]
2023-08-31 16:42:52,282 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMods batching will sleep for 5 seconds before sending slice[2:2]
kytos $>                                                                                                                                                                                

kytos $> 2023-08-31 16:42:57,285 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Sending FlowMods slice[2: 4], iteration: 1, flows[0, 1]: [{'switch': '00:00:00:00:00:00:0
0:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vlan': 3}, 'priority': 4000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 100, 'id': '6f614c8654066e827cce5dc6b3e785cb', 'stats': {
}, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}]
2023-08-31 16:42:57,291 - INFO [uvicorn.access] (MainThread) 127.0.0.1:52294 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202

```

- Made a request with `force: true` with batching, it blocked the request as expected

```
kytos $> 2023-08-31 16:43:14,817 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: True, batch
_size: 2, batch_interval: 5, flows[0, 3]: [{'priority': 4000, 'cookie': 100, 'match': {'in_port': 1, 'dl_vlan': 1}, 'actions': [{'action_type': 'output', 'port': 2}]}, {'priority': 400
0, 'cookie': 100, 'match': {'in_port': 1, 'dl_vlan': 2}, 'actions': [{'action_type': 'output', 'port': 2}]}, {'priority': 4000, 'cookie': 100, 'match': {'in_port': 1, 'dl_vlan': 3}, 'a
ctions': [{'action_type': 'output', 'port': 2}]}]
2023-08-31 16:43:14,852 - INFO [uvicorn.access] (MainThread) 127.0.0.1:45808 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2023-08-31 16:43:14,857 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_12) Sending FlowMods slice[0: 2], iteration: 0, flows[0, 2]: [{'switch': '00:00:00:00:00:00:00:01', 'ta
ble_id': 0, 'match': {'in_port': 1, 'dl_vlan': 1}, 'priority': 4000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 100, 'id': '2e371cca3dcfe383a5058c4410920c1e', 'stats': {}, 'cookie
_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}, {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'
in_port': 1, 'dl_vlan': 2}, 'priority': 4000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 100, 'id': '8f4ebd12d31dba67b36dadfad7ba2c84', 'stats': {}, 'cookie_mask': 0, 'instruction
s': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}]
2023-08-31 16:43:14,872 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_12) Send FlowMods batching will sleep for 5 seconds before sending slice[2:2]
kytos $>                                                                                                                                                                                

kytos $> 2023-08-31 16:43:19,878 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_12) Sending FlowMods slice[2: 4], iteration: 1, flows[0, 1]: [{'switch': '00:00:00:00:00:00:00
:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vlan': 3}, 'priority': 4000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 100, 'id': '6f614c8654066e827cce5dc6b3e785cb', 'stats': {}
, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'port': 2, 'action_type': 'output'}]}]}]

```

- Sent event with 100 flows with batching, it worked as expected (I truncated the output here):

```
kytos $> def create_flows(dpid: str, n: int) -> dict[list]: 
    ...:     """docstring.""" 
    ...:     flows = [ 
    ...:         { 
    ...:             "priority": i, 
    ...:             "cookie": i, 
    ...:             "match": {"in_port": 1, "dl_vlan": i}, 
    ...:             "actions": [{"action_type": "output", "port": 2}], 
    ...:         } 
    ...:         for i in range(1, n + 1) 
    ...:     ] 
    ...:     return { 
    ...:         "flow_dict": { 
    ...:             "flows": flows,
    ...:         }, 
    ...:         "dpid": dpid, 
                 "force": True, 
    ...:         "batch_interval": 1, 
    ...:         "batch_size": 50
    ...:     } 
    ...:  
    ...:  
    ...: data = create_flows(dpid, 100) 
    ...: ev = KytosEvent("kytos.flow_manager.flows.install", content=data) 
    ...: controller.buffers.app.put(ev)                                                                                                                                                 

2023-08-31 16:49:04,584 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_19) Sending FlowMods slice[0: 50], iteration: 0, flows[0, 50]: ...
2023-08-31 16:49:04,660 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_19) Send FlowMods batching will sleep for 1 seconds before sending slice[50:50]
kytos $>                                                                                                                                                                                

kytos $> 2023-08-31 16:49:05,662 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_19) Sending FlowMods slice[50: 100], iteration: 1, flows[0, 50]: ...
```

### End-to-End Tests

```
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 47%]
...                                                                      [ 48%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 72%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 75%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 85%]
tests/test_e2e_50_maintenance.py ........................                [ 95%]
tests/test_e2e_60_of_multi_table.py .....                                [ 97%]
tests/test_e2e_70_kytos_stats.py .......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 219 passed, 6 skipped, 11 xfailed, 5 xpassed, 867 warnings in 11382.39s (3:09:42) =
```
