### PR TITLE
fix: fixed updating flow installed state via `kytos/of_core.flow_stats.received`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,15 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+
 - Augmented ``GET v2/stored_flows`` ``cookie_range`` to accept an even list of ranges
+
+Fixed
+=====
+- Fixed updating flow installed state when handling ``kytos/of_core.flow_stats.received``
+
 
 [2023.1.0] - 2023-06-05
 ***********************

--- a/main.py
+++ b/main.py
@@ -246,12 +246,12 @@ class Main(KytosNApp):
 
         flow_ids_to_update = []
         for flow in pending_flows:
-            _id = flow["_id"]
-            if _id not in installed_flows:
+            flow_id = flow["flow_id"]
+            if flow_id not in installed_flows:
                 continue
 
-            installed_flow = installed_flows[_id]
-            flow_ids_to_update.append(_id)
+            installed_flow = installed_flows[flow_id]
+            flow_ids_to_update.append(flow_id)
             self._send_napp_event(switch, installed_flow, "add")
 
         if flow_ids_to_update:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1054,7 +1054,10 @@ class TestMain:
         switch = get_switch_mock(dpid, 0x04)
         switch.id = dpid
         flow1, flow2 = MagicMock(id="1"), MagicMock(id="2")
-        flow1_dict, flow2_dict = {"_id": flow1.id}, {"_id": flow2.id}
+        flow1_dict, flow2_dict = {"flow_id": flow1.id, "state": "pending"}, {
+            "flow_id": flow2.id,
+            "state": "pending",
+        }
         flow1.__getitem__.side_effect, flow2.__getitem__.side_effect = (
             flow1_dict.__getitem__,
             flow2_dict.__getitem__,


### PR DESCRIPTION
Closes #173, thanks @italovalcy and Renata for catching and reporting this

### Summary

See updated changelog file

### Local Tests

Without this branch and with `settings.ENABLE_BARRIER_REQUEST = False` to help to simulate an equivalent scenario (just so the installed state didn't get update as a consequence of a barrier reply):

```
rs0 [direct: primary] napps> db.flows.find({"state": "pending", "switch": "00:00:00:00:00:00:00:01"}, {"id": 1, "match_id": 1, "state": 1, "switch": 1, "flow": 1})
[
  {
    _id: 'b33f354ca83bfc990537e1d8d0c964e4',
    flow: {
      owner: 'of_lldp',
      cookie: Decimal128("12321848580485677057"),
      match: { dl_type: 35020, dl_vlan: 3799 },
      actions: [ { action_type: 'output', port: Long("4294967293") } ],
      table_id: 0,
      table_group: 'base',
      priority: 50000,
      idle_timeout: 0,
      hard_timeout: 0
    },
    id: 'b33f354ca83bfc990537e1d8d0c964e4',
    state: 'pending',
    switch: '00:00:00:00:00:00:00:01'
  },
  {
    _id: '65402620086103823deb00334b952bcb',
    flow: {
      owner: 'coloring',
      cookie: Decimal128("12393906174523604993"),
      match: { dl_src: 'ee:ee:ee:ee:ee:03' },
      actions: [ { action_type: 'output', port: Long("4294967293") } ],
      table_id: 0,
      table_group: 'base',
      priority: 50000,
      idle_timeout: 0,
      hard_timeout: 0
    },
    id: '65402620086103823deb00334b952bcb',
    state: 'pending',
    switch: '00:00:00:00:00:00:00:01'
  },
  {
    _id: '914c314cfe8591090073a14bec4e659f',
    flow: {
      owner: 'coloring',
      cookie: Decimal128("12393906174523604993"),
      match: { dl_src: 'ee:ee:ee:ee:ee:02' },
      actions: [ { action_type: 'output', port: Long("4294967293") } ],
      table_id: 0,
      table_group: 'base',
      priority: 50000,
      idle_timeout: 0,
      hard_timeout: 0
    },
    id: '914c314cfe8591090073a14bec4e659f',
    state: 'pending',
    switch: '00:00:00:00:00:00:00:01'
  }
]

```
- After restarting the controller, to force switches to reconnect to also trigger more quickly receiving flow stats, and using this branch with `settings.ENABLE_BARRIER_REQUEST = False`. Notice below `pending` flows weren't found anymore in the `flows` DB collection and they got updated as installed since `kytos/of_core.flow_stats.received` is being handled correctly now

```
rs0 [direct: primary] napps> db.flows.find({"state": "pending", "switch": "00:00:00:00:00:00:00:01"}, {"id": 1, "match_id": 1, "state": 1, "switch": 1, "flow": 1})

rs0 [direct: primary] napps> db.flows.find({"state": "installed", "switch": "00:00:00:00:00:00:00:01"}, {"id": 1, "match_id": 1, "state": 1, "switch": 1, "flow": 1})
[
  {
    _id: 'b33f354ca83bfc990537e1d8d0c964e4',
    flow: {
      owner: 'of_lldp',
      cookie: Decimal128("12321848580485677057"),
      match: { dl_type: 35020, dl_vlan: 3799 },
      actions: [ { action_type: 'output', port: Long("4294967293") } ],
      table_id: 0,
      table_group: 'base',
      priority: 50000,
      idle_timeout: 0,
      hard_timeout: 0
    },
    id: 'b33f354ca83bfc990537e1d8d0c964e4',
    state: 'installed',
    switch: '00:00:00:00:00:00:00:01'
  },
  {
    _id: '65402620086103823deb00334b952bcb',
    flow: {
      owner: 'coloring',
      cookie: Decimal128("12393906174523604993"),
      match: { dl_src: 'ee:ee:ee:ee:ee:03' },
      actions: [ { action_type: 'output', port: Long("4294967293") } ],
      table_id: 0,
      table_group: 'base',
      priority: 50000,
      idle_timeout: 0,
      hard_timeout: 0
    },
    id: '65402620086103823deb00334b952bcb',
    state: 'installed',
    switch: '00:00:00:00:00:00:00:01'
  },
  {
    _id: '914c314cfe8591090073a14bec4e659f',
    flow: {
      owner: 'coloring',
      cookie: Decimal128("12393906174523604993"),
      match: { dl_src: 'ee:ee:ee:ee:ee:02' },
      actions: [ { action_type: 'output', port: Long("4294967293") } ],
      table_id: 0,
      table_group: 'base',
      priority: 50000,
      idle_timeout: 0,
      hard_timeout: 0
    },
    id: '914c314cfe8591090073a14bec4e659f',
    state: 'installed',
    switch: '00:00:00:00:00:00:00:01'
  }
]
rs0 [direct: primary] napps> 

```

### End-to-End Tests

e2e tests with this branch:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 252 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 46%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py ....                                      [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py .............                              [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ........                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 230 passed, 6 skipped, 9 xfailed, 7 xpassed, 1109 warnings in 12056.41s (3:20:56) =
```