### PR TITLE
[2023.1.1][backport] fix: fixed updating flow installed state via `kytos/of_core.flow_stats.received`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.1.1] - 2023-11-18
+***********************
+
+Fixed
+=====
+- Fixed updating flow installed state when handling ``kytos/of_core.flow_stats.received``
+
 [2023.1.0] - 2023-06-05
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2023.1.0",
+  "version": "2023.1.1",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -243,12 +243,12 @@ class Main(KytosNApp):
 
         flow_ids_to_update = []
         for flow in pending_flows:
-            _id = flow["_id"]
-            if _id not in installed_flows:
+            flow_id = flow["flow_id"]
+            if flow_id not in installed_flows:
                 continue
 
-            installed_flow = installed_flows[_id]
-            flow_ids_to_update.append(_id)
+            installed_flow = installed_flows[flow_id]
+            flow_ids_to_update.append(flow_id)
             self._send_napp_event(switch, installed_flow, "add")
 
         if flow_ids_to_update:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -999,7 +999,10 @@ class TestMain:
         switch = get_switch_mock(dpid, 0x04)
         switch.id = dpid
         flow1, flow2 = MagicMock(id="1"), MagicMock(id="2")
-        flow1_dict, flow2_dict = {"_id": flow1.id}, {"_id": flow2.id}
+        flow1_dict, flow2_dict = {"flow_id": flow1.id, "state": "pending"}, {
+            "flow_id": flow2.id,
+            "state": "pending",
+        }
         flow1.__getitem__.side_effect, flow2.__getitem__.side_effect = (
             flow1_dict.__getitem__,
             flow2_dict.__getitem__,


### PR DESCRIPTION
Backport of PR #174 for `2023.1` bumping version `2023.1.1`

### Summary

See updated changelog file

### Local Tests

I explored locally with the same test as the linked PR

### End-to-End Tests

See related PR