### PR TITLE
feat: `cookie_range` filter via body too

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changed
 =======
 
 - Augmented ``GET v2/stored_flows`` ``cookie_range`` to accept an even list of ranges
+- Augmented ``GET v2/stored_flows`` ``cookie_range`` to accept this filter via json body too. If both ``cookie_range`` query arg and body are set, the body values will have a higher preference.
 
 Fixed
 =====

--- a/openapi.yml
+++ b/openapi.yml
@@ -163,7 +163,7 @@ paths:
             type: array
             items:
               type: integer
-          description: Inclusive range of cookies. The length of the list must be even, for example, [1, 2, 5, 6], would include from 1 to 2 and from 5 to 6.
+          description: Inclusive range of cookies. The length of the list must be even, for example, [1, 2, 5, 6], would include from 1 to 2 and from 5 to 6. If you are dozens of cookies you might want to send via json body instead.
           required: false
           example: [84114963, 84114965]
       responses:


### PR DESCRIPTION
Closes #176 

### Summary

- See updated changelog file
- For more information why this is needed/recommended, check out [this comment](https://github.com/kytos-ng/flow_manager/issues/176#issuecomment-1833971281)

### Local Tests

- Explored locally setting the json body, worked as expected, it's reusing the same underlying transformations.

### End-to-End Tests

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 254 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ........                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 232 passed, 6 skipped, 9 xfailed, 7 xpassed, 1109 warnings in 12146.74s (3:22:26) =