### PR TITLE
feat: added kytos.flow_manager.flows.single.(install|delete) handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
 - Updated test dependencies
+- Added ``kytos.flow_manager.flows.single.(install|delete)`` handler with ``pool="dynamic_single"``
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,7 @@ Subscribed
 
 - ``kytos/of_core.handshake.completed``
 - ``kytos.flow_manager.flows.(install|delete)``
+- ``kytos.flow_manager.flows.single.(install|delete)``
 - ``kytos/of_core.flow_stats.received``
 - ``kytos/of_core.v0x04.messages.in.ofpt_flow_removed``
 - ``kytos/of_core.v0x04.messages.in.ofpt_barrier_reply``

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -531,16 +531,25 @@ class TestMain:
         mock_send_barrier_request.assert_called()
         self.napp.flow_controller.delete_flows_by_ids.assert_not_called()
 
-    @patch("napps.kytos.flow_manager.main.flows_to_log_info")
-    @patch("napps.kytos.flow_manager.main.Main._install_flows")
-    def test_event_add_flow(self, mock_install_flows, mock_flows_log):
+    @pytest.mark.parametrize(
+        "ev_name",
+        ("kytos.flow_manager.flows.install", "kytos.flow_manager.flows.single.install"),
+    )
+    def test_event_add_flow(self, monkeypatch, ev_name):
         """Test method for installing flows on the switches through events."""
+        mock_install_flows, mock_flows_log = MagicMock(), MagicMock()
+        monkeypatch.setattr(
+            "napps.kytos.flow_manager.main.flows_to_log_info", mock_flows_log
+        )
+        monkeypatch.setattr(
+            "napps.kytos.flow_manager.main.Main._install_flows", mock_install_flows
+        )
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
         self.napp.controller.switches = {dpid: switch}
         mock_flow_dict = {"flows": [MagicMock()]}
         event = get_kytos_event_mock(
-            name="kytos.flow_manager.flows.install",
+            name=ev_name,
             content={"dpid": dpid, "flow_dict": mock_flow_dict},
         )
         self.napp.handle_flows_install_delete(event)
@@ -577,16 +586,25 @@ class TestMain:
         self.napp.handle_flows_install_delete(event)
         assert mock_log.error.call_count == 1
 
-    @patch("napps.kytos.flow_manager.main.flows_to_log_info")
-    @patch("napps.kytos.flow_manager.main.Main._install_flows")
-    def test_event_flows_install_delete(self, mock_install_flows, mock_flows_log):
+    @pytest.mark.parametrize(
+        "ev_name",
+        ("kytos.flow_manager.flows.delete", "kytos.flow_manager.flows.single.delete"),
+    )
+    def test_event_flows_install_delete(self, monkeypatch, ev_name):
         """Test method for removing flows on the switches through events."""
+        mock_install_flows, mock_flows_log = MagicMock(), MagicMock()
+        monkeypatch.setattr(
+            "napps.kytos.flow_manager.main.flows_to_log_info", mock_flows_log
+        )
+        monkeypatch.setattr(
+            "napps.kytos.flow_manager.main.Main._install_flows", mock_install_flows
+        )
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
         self.napp.controller.switches = {dpid: switch}
         mock_flow_dict = {"flows": [MagicMock()]}
         event = get_kytos_event_mock(
-            name="kytos.flow_manager.flows.delete",
+            name=ev_name,
             content={"dpid": dpid, "flow_dict": mock_flow_dict},
         )
         self.napp.handle_flows_install_delete(event)


### PR DESCRIPTION
Closes #185 

### Summary

See updated changelog file 

### Local Tests

- Tested out the same issue, no longer happens. 
- Also used it with `telemetry_int` and `iperf`, it's performing well (5k packets re transmissions in the data plane with failover - which is similar to prior convergence measurements for this kind of network failure / sending flows mods):

```
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-60.00  sec  65.0 GBytes  9.31 Gbits/sec  5578             sender
[  4]   0.00-60.00  sec  65.0 GBytes  9.30 Gbits/sec                  receiver
```

```
2024-06-13 11:49:40,064 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True,  flows[0, 7]: 
[{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 22, 'dl_
vlan': 27, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_
id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port'
: 22, 'dl_vlan': 27, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tabl
e', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match':
 {'in_port': 22, 'dl_vlan': 27}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, 
{'action_type': 'set_vlan', 'vlan_id': 30}, {'action_type': 'output', 'port': 5}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 1217
6856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 30, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', '
actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie':
 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 30, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actio
ns', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'co
okie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 30}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_
type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 121768568646
68478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 30}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, 
{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2024-06-13 11:49:40,088 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: add, force: True,  flows[0, 4]: 
[{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_v
lan': 30, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id'
: 30}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12176856864668478786, 'idle_timeout': 0, 
'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 30, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_
metadata'}, {'action_type': 'set_vlan', 'vlan_id': 30}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'c
ookie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 30, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply
_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 30}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_in
t', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12176856864668478786, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 30, 'dl_type': 2048, 'nw_proto': 
17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 30}, {'action_type': 'output', 'port
```

### End-to-End Tests

For completeness, I'll dispatch an e2e exec, but this handler will only be fully covered with e2e once `telemetry_int` is using it, since this handler `telemetry_int` will be the main user as of now. 
