### PR TITLE
hotfix: increased telemetry_int pacing rate to 300/second

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.3] - 2024-09-05
+***********************
+
+Changed
+=======
+
+- Increased ``telemetry_int`` pacing rate to 300/second
+
+
 [2024.1.1] - 2024-08-30
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2024.1.1",
+  "version": "2024.1.3",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/settings.py
+++ b/settings.py
@@ -40,7 +40,7 @@ ACTION_PACES = {
         "strategy": "fixed_window",
     },
     "send_flow_mod.telemetry_int": {
-        "pace": "100/second",
+        "pace": "300/second",
         "strategy": "fixed_window",
     },
     "send_flow_mod.of_lldp": {


### PR DESCRIPTION
Closes https://github.com/kytos-ng/telemetry_int/issues/40

This PR is assuming that PR #200 will land first, so it's already bumping here `2024.1.3` 

### Summary

See updated changelog file 

### Local Tests

Local tests has been done and documented [on this comment](https://github.com/kytos-ng/telemetry_int/issues/40#issuecomment-2332340160) using the INT NoviFlow lab, check it out to also understand the reason why it's being increased to 300/second

### End-to-End Tests

I'll dispatch an exec with this branch, but no surprises expected since it's just a minor pacing value change:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 243 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12502.88s (3:28:22) =
```
