### PR TITLE
fix dbname for mongo client based on MONGO_DBNAME env var

### DIFF
--- a/scripts/db/2023.1.0/001_pipeline_related.py
+++ b/scripts/db/2023.1.0/001_pipeline_related.py
@@ -1,10 +1,11 @@
+import os
 from kytos.core.db import mongo_client
 from bson.decimal128 import Decimal128
 from decimal import Decimal
 
 
 client = mongo_client()
-collection = client["napps"]["flows"]
+collection = client[os.environ["MONGO_DBNAME"]]["flows"]
 
 # Flows from mef_eline, table groups available: epl, evpl
 query_match = {


### PR DESCRIPTION
Closes #203 

### Summary

- Fixed db migration script `2023.1.0/001_pipeline_related.py` with the correct DB name from MONGO_DBNAME env var

### Local Tests

N/A

### End-to-End Tests

N/A