### PR TITLE
Added requests for flows and bulk of switches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,15 @@ file.
 [2024.1.2] - 2024-09-06
 ***********************
 
+Added
+=====
+- Added new requests ``POST v2/flows_by_switch`` and ``DELETE v2/flows_by_switch`` to modify flows by switch. Both have the parameter ``force`` as a boolean to ignore switch connectivity errors.
+
 Changed
 =======
 - Changed alien flows to have ``alien`` as owner. Alien flow deletion is now paced by ``send_flow_mod.alien``.
 - Increased ``telemetry_int`` pacing rate to 300/second
+- Added ``switches`` proterty to requests ``POST v2/flows`` and ``DELETE v2/flows`` to add flows to all switches in the list from ``switches``
 
 [2024.1.1] - 2024-08-30
 ***********************

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -5,7 +5,7 @@ import os
 from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, Union
 
 import pymongo
 from bson.decimal128 import Decimal128
@@ -142,32 +142,40 @@ class FlowController:
             yield flow
 
     def get_flows_by_cookie_ranges(
-        self, dpids: list[str], cookie_ranges: list[tuple[int, int]]
+        self, dpids: list[str],
+        cookie_collection: Union[
+            dict[str, list[tuple[int, int]]], # by_switch=True
+            list[tuple[int, int]], # by_switch=False
+        ],
+        by_switch=False,
     ) -> dict:
-        """Get flows by cookie ranges [low, high] (inclusive) grouped by dpid."""
-        query_match = {
-            "$match": {
-                "switch": {"$in": dpids},
+        """Get flows by cookie ranges [low, high] by switches."""
+        pipeline = []
+        match_filter = {"$or": []}
+        for dpid in dpids:
+            if by_switch:
+                cookie_range = cookie_collection[dpid]
+            else:
+                cookie_range = cookie_collection
+            match_filter["$or"].append({
+                "switch": dpid,
                 "state": {"$ne": "deleted"},
-            }
-        }
-        if cookie_ranges:
-            query_match["$match"]["$or"] = [
-                {
-                    "flow.cookie": {
-                        "$gte": Decimal128(Decimal(low)),
-                        "$lte": Decimal128(Decimal(high)),
+                "$or": [
+                    {
+                        "flow.cookie": {
+                            "$gte": Decimal128(Decimal(low)),
+                            "$lte": Decimal128(Decimal(high)),
+                        }
                     }
-                }
-                for low, high in cookie_ranges
-            ]
+                    for low, high in cookie_range
+                ]
+            })
+        pipeline.append({"$match": match_filter})
+        pipeline.append({
+            "$group": {"_id": "$switch", "flows": {"$push": "$$ROOT"}}
+        })
         flows = defaultdict(list)
-        for document in self.db.flows.aggregate(
-            [
-                query_match,
-                {"$group": {"_id": "$switch", "flows": {"$push": "$$ROOT"}}},
-            ]
-        ):
+        for document in self.db.flows.aggregate(pipeline):
             for flow in document["flows"]:
                 flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
                 flows[flow["switch"]].append(flow)

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import time
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from threading import Lock
-from typing import Optional
+from typing import Optional, Union
 
 from napps.kytos.flow_manager.match import match_flow
 from napps.kytos.of_core.flow import FlowFactory
@@ -398,15 +398,15 @@ class Main(KytosNApp):
                 self._install_flows("add", flow_dict, [switch], save=False)
                 flows_to_log(
                     log.info,
-                    f"Flows forwarded to be installed to switch ",
-                    [dpid],
+                    f"Flows forwarded to be installed to switches ",
+                    [switch.id],
                     flow_dict,
                 )
             except SwitchNotConnectedError:
                 flows_to_log(
                     log.error,
-                    f"Failed to forward flows to be installed to switch ",
-                    [dpid],
+                    f"Failed to forward flows to be installed to switches ",
+                    [switch.id],
                     flow_dict,
                 )
 
@@ -457,38 +457,19 @@ class Main(KytosNApp):
                 self._install_flows(command, flow_dict, [switch], save=False)
                 flows_to_log(
                     log.info,
-                    f"Flows forwarded  to be deleted to switch ",
-                    [dpid],
+                    f"Flows forwarded  to be deleted to switches ",
+                    [switch.id],
                     flow_dict,
                 )
             except SwitchNotConnectedError:
                 flows_to_log(
                     log.error,
-                    f"Failed to forward flows  to be deleted to switch ",
-                    [dpid],
+                    f"Failed to forward flows  to be deleted to switches ",
+                    [switch.id],
                     flow_dict,
                 )
 
-    def get_flows_by_cookie_ranges(self, dpids: list[str], cookie_ranges_dict: dict[str, list[tuple[int, int]]]) -> dict:
-        """Avoid multiple DB searches when all or consecutive switches have the same cookie range."""
-        if len(dpids) == 1:
-            return self.flow_controller.get_flows_by_cookie_ranges(dpids, cookie_ranges_dict[dpids[0]])
-        dpids_acc = []
-        flows = {}
-        prev_range = cookie_ranges_dict[dpids[0]]
-        for i, dpid in enumerate(dpids):
-            if not cookie_ranges_dict[dpid]:
-                continue
-                
-            dpids_acc.append(dpid)
-            if (cookie_ranges_dict[dpid] == prev_range and len(dpids) - 1 != i):
-                continue 
-            flows.update(self.flow_controller.get_flows_by_cookie_ranges(dpids_acc, cookie_ranges_dict[dpid]))
-            prev_range = cookie_ranges_dict[dpid]
-            dpids_acc = []
-        return flows
-
-    def delete_matched_flows(self, flow_dicts: dict, switches: dict) -> None:
+    def delete_matched_flows(self, flow_dicts: dict, switches: dict, by_switch=False) -> None:
         """Try to delete many matched stored flows given flow_dicts for switches.
 
         This deletion tries to minimize DB round trips, it aggregates all
@@ -498,6 +479,8 @@ class Main(KytosNApp):
         """
         deleted_flows = {}
         cookie_ranges_dict = {}
+        switches_list = list(switches.keys())
+
         for dpid in flow_dicts:
             cookie_ranges_dict[dpid] = list(
                 {
@@ -508,11 +491,18 @@ class Main(KytosNApp):
                     for value in [flow.get("flow", {}) for flow in flow_dicts[dpid]]
                 }
             )
-        for dpid, cookie_ranges in cookie_ranges_dict.items():
-            cookie_ranges_dict[dpid] = merge_cookie_ranges(cookie_ranges)
-        for dpid, stored_flows in self.get_flows_by_cookie_ranges(
-            list(switches.keys()), cookie_ranges_dict
-        ).items():
+            if not by_switch:
+                # All the switches have the same cookie ranges
+                # no more looping necessary
+                cookie_ranges = merge_cookie_ranges(cookie_ranges_dict[dpid])
+                flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(switches_list, cookie_ranges)
+                break
+        if by_switch:
+            for dpid, cookie_ranges in cookie_ranges_dict.items():
+                cookie_ranges_dict[dpid] = merge_cookie_ranges(cookie_ranges)
+            flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(switches_list, cookie_ranges_dict, by_switch=True)
+
+        for dpid, stored_flows in flows_from_db.items():
             for flow_dict in flow_dicts[dpid]:
                 for stored_flow in stored_flows:
                     if stored_flow["id"] in deleted_flows:
@@ -670,7 +660,7 @@ class Main(KytosNApp):
         flows_to_log(
             log.info,
             f"Send FlowMod from KytosEvent command: {command}, "
-            f"force: {force}, dpid: ",
+            f"force: {force}, dpids: ",
             [dpid],
             flow_dict,
         )
@@ -691,14 +681,14 @@ class Main(KytosNApp):
         """Install new flows by switch specified in the content"""
         force = request.query_params.get("force")
         force = True if not force or force.lower() == "true" else False
-        return self._send_flows_by_switch_from_request(request, "add", force)
+        return self._send_flows_by_switch_from_request(request, "add", force, by_switch=True)
 
     @rest("v2/flows_by_switch", methods=["DELETE"])
     def delete_by_switch(self, request: Request) -> JSONResponse:
         """Install new flows by switch specified in the content"""
         force = request.query_params.get("force")
         force = True if not force or force.lower() == "true" else False
-        return self._send_flows_by_switch_from_request(request, "delete", force)
+        return self._send_flows_by_switch_from_request(request, "delete", force, by_switch=True)
 
     @rest("v2/flows", methods=["POST"])
     @rest("v2/flows/{dpid}", methods=["POST"])
@@ -722,10 +712,16 @@ class Main(KytosNApp):
         dpid = request.path_params.get("dpid")
         return self._send_flow_mods_from_request(request, dpid, "delete")
 
-    def _get_all_switches_enabled(self):
-        """Get a list of all switches enabled."""
+    def _get_all_switches_enabled(self) -> tuple[list, list]:
+        """Get a list of all switches enabled and a list of their ids."""
         switches = self.controller.switches.values()
-        return [switch for switch in switches if switch.is_enabled()]
+        switches_list = []
+        switch_ids = []
+        for switch in switches:
+            if switch.is_enabled():
+                switches_list.append(switch)
+                switch_ids.append(switch.id)
+        return switches_list, switch_ids
 
     def _send_flow_mods_from_request(
         self, request: Request, dpid: Optional[str], command: str
@@ -748,8 +744,23 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=str(exc))
 
         force = bool(flows_dict.get("force", False))
+        switches = []
+        switch_dpids = []
         if not dpid:
-            switches = self._get_all_switches_enabled()
+            switches_list = flows_dict.get("switches", None)
+            if switches_list:
+                if not isinstance(switches_list, list):
+                    raise HTTPException(400, detail=f"Switches should be in a list.")
+                for dpid in flows_dict.get("switches"):
+                    switch = self.controller.get_switch_by_dpid(dpid)
+                    if not switch:
+                        return JSONResponse({"response": "dpid not found."}, status_code=404)
+                    if not switch.is_enabled() and command == "add":
+                        raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
+                    switches.append(switch)
+                switch_dpids = switches_list
+            else:
+                switches, switch_dpids = self._get_all_switches_enabled()
         else:
             switches = self.controller.get_switch_by_dpid(dpid)
             if not switches:
@@ -757,12 +768,13 @@ class Main(KytosNApp):
 
             if not switches.is_enabled() and command == "add":
                 raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
+            switch_dpids = [switches.id]
             switches = [switches]
 
         flows_to_log(
             log.info,
-            f"Send FlowMod from request command: {command}, force: {force}, dpid: ",
-            [switches],
+            f"Send FlowMod from request command: {command}, force: {force}, dpids: ",
+            switch_dpids,
             flows_dict,
         )
         try:
@@ -793,29 +805,33 @@ class Main(KytosNApp):
     def _install_flows(
         self,
         command: str,
-        flows_dict: dict,
+        flows_dict_content: dict,
         switches=[],
         save=True,
         reraise_conn=True,
         send_barrier=ENABLE_BARRIER_REQUEST,
+        by_switch=False,
     ):
         """Execute all procedures to bulk install flows in the switches.
 
         Args:
             command: Flow command to be installed
-            flows_dict: Dictionary with flows to be installed in the switches.
+            flows_dict_content: Two possible dictionary values depending on by_switch
+                False: Dictionary with "flows" as key and a list as value
+                True: Dictionary with dpid as key and flows dictionary as value
             switches: A list of switches
             save: A boolean to save flows in the database
             reraise_conn: True to reraise switch connection errors
             send_barrier: True to send barrier_request
+            by_switch: False if the flows are installed in all switches are the same.
         """
         flow_mods, flows = defaultdict(list), defaultdict(list)
         flows_dict_by_switch, owners = defaultdict(list), defaultdict(list)
         for switch in switches:
             serializer = FlowFactory.get_class(switch, Flow04)
-            flows_list = flows_dict.get("flows", [])
+            flows_list = flows_dict_content.get("flows", [])
             if not flows_list:
-                flows_list = flows_dict.get(switch.id, {}).get("flows", [])
+                flows_list = flows_dict_content.get(switch.id, {}).get("flows", [])
             for flow_dict in flows_list:
                 try:
                     flow = serializer.from_dict(flow_dict, switch)
@@ -834,14 +850,15 @@ class Main(KytosNApp):
                     {"flow": flow_dict, "flow_id": flow.id, "switch": switch.id}
                 )
         if save and command == "add":
+            match_ids = []
+            flow_dicts = []
             for switch in switches:
-                self.flow_controller.upsert_flows(
-                    [flow.match_id for flow in flows[switch.dpid]],
-                    flows_dict_by_switch[switch.dpid]
-                )
+                match_ids.extend([flow.match_id for flow in flows[switch.dpid]])
+                flow_dicts.extend(flows_dict_by_switch[switch.dpid])
+            self.flow_controller.upsert_flows(match_ids, flow_dicts)
         if save and command == "delete":
             self.delete_matched_flows(
-                flows_dict_by_switch, {switch.id: switch for switch in switches}
+                flows_dict_by_switch, {switch.id: switch for switch in switches}, by_switch
             )
         self._send_flow_mods(
             switches, flow_mods, flows, owners, reraise_conn, send_barrier
@@ -849,10 +866,10 @@ class Main(KytosNApp):
 
     def _send_flow_mods(
         self,
-        switches,
-        flow_mods,
-        flows,
-        owners,
+        switches: list,
+        flow_mods: dict[str, list],
+        flows: dict[str, list],
+        owners: dict[str, list],
         reraise_conn=True,
         send_barrier=ENABLE_BARRIER_REQUEST,
     ):
@@ -881,6 +898,7 @@ class Main(KytosNApp):
         request: Request,
         command: str,
         force: bool,
+        by_switch=False,
     ) -> JSONResponse:
         """Send flows in the respective switches from request."""
         content_type_json_or_415(request)
@@ -893,8 +911,9 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=result)
         
         switches = []
+        switch_ids = []
         for dpid in content_dict:
-            flows = content_dict[dpid]["flows"]
+            flows = content_dict[dpid].get("flows", [])
             if not any(flows):
                 result = f"The switch {dpid} in the request body doesn't have any flows"
                 raise HTTPException(400, detail=result)
@@ -906,19 +925,25 @@ class Main(KytosNApp):
             switch = self.controller.get_switch_by_dpid(dpid)
             if not switch:
                 return JSONResponse({"response": "dpid not found."}, status_code=404)
+            if not switch.is_enabled() and command == "add":
+                raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
             switches.append(switch)
+            switch_ids.append(dpid)
 
         flows_to_log(
             log.info,
             f"Send FlowMod from request command: {command}, "
-            f"force: {force}, dpid: ",
-            [switches],
+            f"force: {force}, dpids: ",
+            switch_ids,
             content_dict,
-            by_switch=True,
+            by_switch,
         )
 
         try:
-            self._install_flows(command, content_dict, switches, reraise_conn=not force)
+            self._install_flows(
+                command, content_dict, switches,
+                reraise_conn=not force, by_switch=by_switch
+            )
             return JSONResponse(
                 {"response": "FlowMod Message Sent"},
                 status_code=202

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 """kytos/flow_manager NApp installs, lists and deletes switch flows."""
 
-# pylint: disable=relative-beyond-top-level,too-many-function-args
+# pylint: disable=relative-beyond-top-level,too-many-function-args, too-many-lines
 import json
 import time
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from threading import Lock
-from typing import Optional, Union
+from typing import Optional
 
 from napps.kytos.flow_manager.match import match_flow
 from napps.kytos.of_core.flow import FlowFactory
@@ -52,6 +52,7 @@ from .settings import (
     FLOWS_DICT_MAX_SIZE,
 )
 from .utils import (
+    _get_force_from_params,
     _valid_consistency_ignored,
     build_command_from_flow_mod,
     build_cookie_range_tuple,
@@ -398,14 +399,14 @@ class Main(KytosNApp):
                 self._install_flows("add", flow_dict, [switch], save=False)
                 flows_to_log(
                     log.info,
-                    f"Flows forwarded to be installed to switches ",
+                    "Flows forwarded to be installed to switches ",
                     [switch.id],
                     flow_dict,
                 )
             except SwitchNotConnectedError:
                 flows_to_log(
                     log.error,
-                    f"Failed to forward flows to be installed to switches ",
+                    "Failed to forward flows to be installed to switches ",
                     [switch.id],
                     flow_dict,
                 )
@@ -457,19 +458,21 @@ class Main(KytosNApp):
                 self._install_flows(command, flow_dict, [switch], save=False)
                 flows_to_log(
                     log.info,
-                    f"Flows forwarded  to be deleted to switches ",
+                    "Flows forwarded  to be deleted to switches ",
                     [switch.id],
                     flow_dict,
                 )
             except SwitchNotConnectedError:
                 flows_to_log(
                     log.error,
-                    f"Failed to forward flows  to be deleted to switches ",
+                    "Failed to forward flows  to be deleted to switches ",
                     [switch.id],
                     flow_dict,
                 )
 
-    def delete_matched_flows(self, flow_dicts: dict, switches: dict, by_switch=False) -> None:
+    def delete_matched_flows(
+        self, flow_dicts: dict, switches: dict, by_switch=False
+    ) -> None:
         """Try to delete many matched stored flows given flow_dicts for switches.
 
         This deletion tries to minimize DB round trips, it aggregates all
@@ -495,13 +498,16 @@ class Main(KytosNApp):
                 # All the switches have the same cookie ranges
                 # no more looping necessary
                 cookie_ranges = merge_cookie_ranges(cookie_ranges_dict[dpid])
-                flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(switches_list, cookie_ranges)
+                flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(
+                    switches_list, cookie_ranges
+                )
                 break
         if by_switch:
             for dpid, cookie_ranges in cookie_ranges_dict.items():
                 cookie_ranges_dict[dpid] = merge_cookie_ranges(cookie_ranges)
-            flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(switches_list, cookie_ranges_dict, by_switch=True)
-
+            flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(
+                switches_list, cookie_ranges_dict, by_switch=True
+            )
         for dpid, stored_flows in flows_from_db.items():
             for flow_dict in flow_dicts[dpid]:
                 for stored_flow in stored_flows:
@@ -679,16 +685,14 @@ class Main(KytosNApp):
     @rest("v2/flows_by_switch", methods=["POST"])
     def add_by_switch(self, request: Request) -> JSONResponse:
         """Install new flows by switch specified in the content"""
-        force = request.query_params.get("force")
-        force = True if not force or force.lower() == "true" else False
-        return self._send_flows_by_switch_from_request(request, "add", force, by_switch=True)
+        return self._send_flow_mods_from_request(request, None, "add", by_switch=True)
 
     @rest("v2/flows_by_switch", methods=["DELETE"])
     def delete_by_switch(self, request: Request) -> JSONResponse:
         """Install new flows by switch specified in the content"""
-        force = request.query_params.get("force")
-        force = True if not force or force.lower() == "true" else False
-        return self._send_flows_by_switch_from_request(request, "delete", force, by_switch=True)
+        return self._send_flow_mods_from_request(
+            request, None, "delete", by_switch=True
+        )
 
     @rest("v2/flows", methods=["POST"])
     @rest("v2/flows/{dpid}", methods=["POST"])
@@ -723,8 +727,49 @@ class Main(KytosNApp):
                 switch_ids.append(switch.id)
         return switches_list, switch_ids
 
+    def _get_switches_from_request_content(
+        self,
+        flows_dict: dict,
+        dpid: Optional[str],
+        command: str,
+    ) -> tuple[list, list]:
+        """Return switches found in the content in a list or in the parameters of
+        the request. Otherwise return all existing and enabled switches."""
+        switch_dpids = []
+        switches = []
+        if not dpid:
+            switches_list = flows_dict.get("switches", None)
+            if switches_list:
+                if not isinstance(switches_list, list):
+                    raise HTTPException(400, detail="Switches should be in a list.")
+                for switch_id in flows_dict.get("switches"):
+                    switch = self.controller.get_switch_by_dpid(switch_id)
+                    if not switch:
+                        raise HTTPException(404, detail={"response": "dpid not found."})
+                    if not switch.is_enabled() and command == "add":
+                        msg = f"Switch {switch_id} is disabled."
+                        raise HTTPException(404, detail=msg)
+                    switches.append(switch)
+                switch_dpids = switches_list
+            else:
+                switches, switch_dpids = self._get_all_switches_enabled()
+        else:
+            switches = self.controller.get_switch_by_dpid(dpid)
+            if not switches:
+                raise HTTPException(404, detail={"response": "dpid not found."})
+
+            if not switches.is_enabled() and command == "add":
+                raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
+            switch_dpids = [switches.id]
+            switches = [switches]
+        return switches, switch_dpids
+
     def _send_flow_mods_from_request(
-        self, request: Request, dpid: Optional[str], command: str
+        self,
+        request: Request,
+        dpid: Optional[str],
+        command: str,
+        by_switch=False,
     ):
         """Install FlowsMods from request."""
         content_type_json_or_415(request)
@@ -733,49 +778,35 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=f"Invalid payload: {flows_dict}")
 
         # Get flow to check if the request is well-formed
-        flows = flows_dict.get("flows", [])
-        if not any(flows_dict) or not any(flows):
+        if not any(flows_dict):
             result = "The request body doesn't have any flows"
             raise HTTPException(400, detail=result)
 
-        try:
-            validate_cookies_and_masks(flows, command)
-        except ValueError as exc:
-            raise HTTPException(400, detail=str(exc))
-
-        force = bool(flows_dict.get("force", False))
-        switches = []
-        switch_dpids = []
-        if not dpid:
-            switches_list = flows_dict.get("switches", None)
-            if switches_list:
-                if not isinstance(switches_list, list):
-                    raise HTTPException(400, detail=f"Switches should be in a list.")
-                for dpid in flows_dict.get("switches"):
-                    switch = self.controller.get_switch_by_dpid(dpid)
-                    if not switch:
-                        return JSONResponse({"response": "dpid not found."}, status_code=404)
-                    if not switch.is_enabled() and command == "add":
-                        raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
-                    switches.append(switch)
-                switch_dpids = switches_list
-            else:
-                switches, switch_dpids = self._get_all_switches_enabled()
+        if by_switch:
+            force = _get_force_from_params(request.query_params)
+            switches, switch_dpids = self._get_switches_from_request_by_switch(
+                flows_dict, command
+            )
         else:
-            switches = self.controller.get_switch_by_dpid(dpid)
-            if not switches:
-                return JSONResponse({"response": "dpid not found."}, status_code=404)
-
-            if not switches.is_enabled() and command == "add":
-                raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
-            switch_dpids = [switches.id]
-            switches = [switches]
+            force = bool(flows_dict.get("force", False))
+            flows = flows_dict.get("flows", [])
+            if not any(flows):
+                result = "The request body doesn't have any flows"
+                raise HTTPException(400, detail=result)
+            try:
+                validate_cookies_and_masks(flows, command)
+            except ValueError as exc:
+                raise HTTPException(400, detail=str(exc))
+            switches, switch_dpids = self._get_switches_from_request_content(
+                flows_dict, dpid, command
+            )
 
         flows_to_log(
             log.info,
             f"Send FlowMod from request command: {command}, force: {force}, dpids: ",
             switch_dpids,
             flows_dict,
+            by_switch,
         )
         try:
             if not dpid:
@@ -849,16 +880,20 @@ class Main(KytosNApp):
                 flows_dict_by_switch[switch.id].append(
                     {"flow": flow_dict, "flow_id": flow.id, "switch": switch.id}
                 )
+
         if save and command == "add":
-            match_ids = []
-            flow_dicts = []
+            flows_to_db = {}
             for switch in switches:
-                match_ids.extend([flow.match_id for flow in flows[switch.dpid]])
-                flow_dicts.extend(flows_dict_by_switch[switch.dpid])
-            self.flow_controller.upsert_flows(match_ids, flow_dicts)
+                for flow, flow_dict in zip(
+                    flows[switch.dpid], flows_dict_by_switch[switch.id]
+                ):
+                    flows_to_db[flow.match_id] = flow_dict
+            self.flow_controller.upsert_flows(flows_to_db.keys(), flows_to_db.values())
         if save and command == "delete":
             self.delete_matched_flows(
-                flows_dict_by_switch, {switch.id: switch for switch in switches}, by_switch
+                flows_dict_by_switch,
+                {switch.id: switch for switch in switches},
+                by_switch,
             )
         self._send_flow_mods(
             switches, flow_mods, flows, owners, reraise_conn, send_barrier
@@ -875,7 +910,9 @@ class Main(KytosNApp):
     ):
         """Send FlowMod (and BarrierRequest) given a list of flow_dicts to switches."""
         for switch in switches:
-            for i, (flow_mod, flow, owner) in enumerate(zip(flow_mods[switch.id], flows[switch.id], owners[switch.id])):
+            for i, (flow_mod, flow, owner) in enumerate(
+                zip(flow_mods[switch.id], flows[switch.id], owners[switch.id])
+            ):
                 try:
                     self._send_flow_mod(switch, flow_mod, owner)
                     if send_barrier and i == len(flow_mods[switch.id]) - 1:
@@ -893,27 +930,21 @@ class Main(KytosNApp):
                 self._send_napp_event(switch, flow, "pending")
         return flow_mods
 
-    def _send_flows_by_switch_from_request(
+    def _get_switches_from_request_by_switch(
         self,
-        request: Request,
+        content_dict: dict,
         command: str,
-        force: bool,
-        by_switch=False,
-    ) -> JSONResponse:
-        """Send flows in the respective switches from request."""
-        content_type_json_or_415(request)
-        content_dict = get_json_or_400(request, self.controller.loop)
-        if not isinstance(content_dict, dict):
-            raise HTTPException(400, detail=f"Invalid payload: {content_dict}")
-
-        if not any(content_dict):
-            result = "The request body doesn't have any flows"
-            raise HTTPException(400, detail=result)
-        
+    ) -> tuple[list, list]:
+        """Return the switches found in request content as keys. Validates the
+        flows content while also verifying the switches."""
         switches = []
         switch_ids = []
         for dpid in content_dict:
-            flows = content_dict[dpid].get("flows", [])
+            switch_content = content_dict[dpid]
+            if not isinstance(switch_content, dict):
+                result = "The content of the switch should be an object."
+                raise HTTPException(400, detail=result)
+            flows = switch_content.get("flows", [])
             if not any(flows):
                 result = f"The switch {dpid} in the request body doesn't have any flows"
                 raise HTTPException(400, detail=result)
@@ -921,42 +952,15 @@ class Main(KytosNApp):
                 validate_cookies_and_masks(flows, command)
             except ValueError as exc:
                 raise HTTPException(400, detail=str(exc))
-            
+
             switch = self.controller.get_switch_by_dpid(dpid)
             if not switch:
-                return JSONResponse({"response": "dpid not found."}, status_code=404)
+                raise HTTPException(404, detail="dpid not found.")
             if not switch.is_enabled() and command == "add":
                 raise HTTPException(404, detail=f"Switch {dpid} is disabled.")
             switches.append(switch)
             switch_ids.append(dpid)
-
-        flows_to_log(
-            log.info,
-            f"Send FlowMod from request command: {command}, "
-            f"force: {force}, dpids: ",
-            switch_ids,
-            content_dict,
-            by_switch,
-        )
-
-        try:
-            self._install_flows(
-                command, content_dict, switches,
-                reraise_conn=not force, by_switch=by_switch
-            )
-            return JSONResponse(
-                {"response": "FlowMod Message Sent"},
-                status_code=202
-            )
-        except SwitchNotConnectedError as error:
-            raise HTTPException(424, detail=str(error))
-        except PackException as error:
-            raise HTTPException(400, detail=str(error))
-        except FlowSerializerError as error:
-            raise HTTPException(400, detail=str(error))
-        except ValidationError as error:
-            msg = error_msg(error.errors())
-            raise HTTPException(400, detail=msg) from error
+        return (switches, switch_ids)
 
     def _add_flow_mod_sent(self, xid, flow, command, owner):
         """Add the flow mod to the list of flow mods sent."""

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   title: kytos/flow_manager
   version: 1.1.0
@@ -82,9 +82,10 @@ paths:
           application/json:
             schema:
               type: object
-              properties:
-                switch_id:
+              patternProperties:
+                '([0-9a-fA-F]{2}:){7}[1-9a-fA-F]{2}':
                   $ref: '#/components/schemas/FlowsBody'
+              examples: [{"00:00:00:00:00:00:00:03": {"flows":[{}]}}]
       responses:
         '202':
           description: FlowMod messages sent.
@@ -113,9 +114,10 @@ paths:
           application/json:
             schema:
               type: object
-              properties:
-                switch_id:
+              patternProperties:
+                '([0-9a-fA-F]{2}:){7}[1-9a-fA-F]{2}':
                   $ref: '#/components/schemas/FlowsBody'
+              examples: [{"00:00:00:00:00:00:00:03": {"flows":[{}]}}]
       responses:
         '202':
           description: FlowMod messages sent.

--- a/openapi.yml
+++ b/openapi.yml
@@ -314,37 +314,47 @@ components:
         in_port:
           type: integer
           format: int16
-          example: 2
+          examples:
+            - 2
         dl_src:
           type: string
-          example: '00:1f:3a:3e:9a:cf'
+          examples:
+            - '00:1f:3a:3e:9a:cf'
         dl_dst:
           type: string
-          example: '00:15:af:d5:38:98'
+          examples: 
+            - '00:15:af:d5:38:98'
         dl_type:
           type: integer
           format: int16
-          example: 2048
+          examples:
+            - 2048
         dl_vlan:
           oneOf:
             - type: string
-              example: "40/4088"
+              examples:
+                - "40/4088"
             - type: integer
-              example: 40
+              examples:
+                - 40
         dl_vlan_pcp:
           type: integer
           format: int8
-          example: 0
+          examples:
+            - 0
         nw_src:
           type: string
-          example: '192.168.0.1'
+          examples:
+            - '192.168.0.1'
         nw_dst:
           type: string
-          example: '192.168.0.2'
+          examples:
+            - '192.168.0.2'
         nw_proto:
           type: integer
           format: int8
-          example: 17
+          examples:
+            - 17
     Actions:
       type: array
       items:
@@ -353,12 +363,14 @@ components:
           action_type:
             type: string
             enum: [set_vlan, output]
-            example: 'output'
+            examples:
+              - 'output'
           value:
             type: integer
             format: int16
-            example: 7
-      example:
+            examples:
+              - 7
+      examples:
       - {
           "action_type": "output",
           "port": 42
@@ -373,19 +385,23 @@ components:
         priority:
           type: integer
           format: int16
-          example: 10
+          examples:
+            - 10
         idle_timeout:
           type: integer
           format: int16
-          example: 360
+          examples:
+            - 360
         hard_timeout:
           type: integer
           format: int16
-          example: 1200
+          examples:
+            - 1200
         cookie:
           type: integer
           format: int64
-          example: 84114904
+          examples:
+            - 84114904
         match:
           $ref: '#/components/schemas/Match'
         actions:
@@ -415,7 +431,8 @@ components:
           type: array
           items:
             type: string
-          example: ["00:00:00:00:00:00:00:01","00:00:00:00:00:00:00:02"]
+          examples:
+            - ["00:00:00:00:00:00:00:01","00:00:00:00:00:00:00:02"]
           
     FlowDoc:
       type: object
@@ -431,6 +448,4 @@ components:
         updated_at:
           type: string
         flow: 
-          type: object
-          items:
-            $ref: '#/components/schemas/Flow'
+          $ref: '#/components/schemas/Flow'

--- a/openapi.yml
+++ b/openapi.yml
@@ -62,6 +62,68 @@ paths:
           description: FlowMod messages sent.
         '400':
            description: Invalid JSON flow.
+  '/api/kytos/flow_manager/v2/flows_by_switch':
+    post:
+      tags:
+        - Add
+      summary: Insert flows by switch.
+      parameters:
+        - name: force
+          schema:
+            type: string
+          description: Option to ignore switch connection errors.
+          required: false
+          example: "true"
+      requestBody:
+        description: Flows by the especified switch.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                switch_id:
+                  $ref: '#/components/schemas/FlowsBody'
+      responses:
+        '202':
+          description: FlowMod messages sent.
+        '400':
+           description: Invalid JSON flow.
+        '404':
+          description: Datapath not found.
+        '424':
+          description: Switch connection error.
+    delete:
+      tags:
+        - Delete
+      summary: Remove flows by matched switch.
+      parameters:
+        - name: force
+          schema:
+            type: string
+          description: Option to ignore switch connection errors.
+          required: false
+          example: "true"
+      requestBody:
+        description: Cookie ranges by the especified switch.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                switch_id:
+                  $ref: '#/components/schemas/FlowsBody'
+      responses:
+        '202':
+          description: FlowMod messages sent.
+        '400':
+           description: Invalid JSON flow.
+        '404':
+          description: Datapath not found.
+        '424':
+          description: Switch connection error.
+        
   '/api/kytos/flow_manager/v2/flows/{dpid}':
     get:
       tags:
@@ -108,6 +170,8 @@ paths:
            description: Invalid JSON flow.
         '404':
           description: Datapath not found.
+        '424':
+          description: Switch not connected.
     delete:
       tags:
         - Delete

--- a/openapi.yml
+++ b/openapi.yml
@@ -69,8 +69,9 @@ paths:
       summary: Insert flows by switch.
       parameters:
         - name: force
+          in: query
           schema:
-            type: string
+            type: boolean
           description: Option to ignore switch connection errors.
           required: false
           example: "true"
@@ -99,8 +100,9 @@ paths:
       summary: Remove flows by matched switch.
       parameters:
         - name: force
+          in: query
           schema:
-            type: string
+            type: boolean
           description: Option to ignore switch connection errors.
           required: false
           example: "true"
@@ -407,6 +409,12 @@ components:
           type: boolean
           description: The force option is for ignoring switch connection errors, and delegating the flows to be automatically sent later on via consistency check.
           default: false
+        switches:
+          type: array
+          items:
+            type: string
+          example: ["00:00:00:00:00:00:00:01","00:00:00:00:00:00:00:02"]
+          
     FlowDoc:
       type: object
       properties:

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -113,19 +113,28 @@ class TestFlowController:  # pylint: disable=too-many-public-methods
         assert not list(
             self.flow_controller.get_flows_by_cookie_ranges([self.dpid], cookie_ranges)
         )
-        args = self.flow_controller.db.flows.aggregate.call_args[0]
-        assert args[0][0]["$match"] == {
-            "switch": {"$in": [self.dpid]},
-            "state": {"$ne": "deleted"},
-            "$or": [
-                {
-                    "flow.cookie": {
-                        "$gte": Decimal128(Decimal(cookie_ranges[0][0])),
-                        "$lte": Decimal128(Decimal(cookie_ranges[0][1])),
+        expected = [
+            {
+                "switch": self.dpid,
+                "state": {"$ne": "deleted"},
+                "$or": [
+                    {
+                        "flow.cookie": {
+                            "$gte": Decimal128(Decimal(cookie_ranges[0][0])),
+                            "$lte": Decimal128(Decimal(cookie_ranges[0][1])),
+                        }
                     }
-                }
-            ],
-        }
+                ],
+            }
+        ]
+        args = self.flow_controller.db.flows.aggregate.call_args[0]
+        assert args[0][0]["$match"]["$or"] == expected
+
+        self.flow_controller.get_flows_by_cookie_ranges(
+            [self.dpid], {self.dpid: cookie_ranges}, by_switch=True
+        )
+        args = self.flow_controller.db.flows.aggregate.call_args[0]
+        assert args[0][0]["$match"]["$or"] == expected
 
     def test_get_flows_by_state(self) -> None:
         """Test get_flows_by_state."""

--- a/utils.py
+++ b/utils.py
@@ -1,12 +1,15 @@
 """kytos/flow_manager utils."""
 
 from collections.abc import Callable
+from typing import Union
 
 from pyof.foundation.base import UBIntBase
 from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
-from typing import Union
+from starlette.datastructures import QueryParams
+
 from kytos.core import log
-from typing import Union
+from kytos.core.rest_api import HTTPException
+
 from .exceptions import InvalidCommandError
 
 
@@ -188,35 +191,36 @@ def validate_cookies_del(flows: list[dict]) -> None:
                 f"when deleting flows. flow: {flow}"
             )
 
+
 def flows_to_log(
     logger_fun: Callable,
     message: str,
     switches: list[str],
     flows_dict: Union[
-        dict[str, dict[str, list]], # by_switch=True
-        dict[str, list]             # by_switch=False
+        dict[str, dict[str, list]], dict[str, list]  # by_switch=True  # by_switch=False
     ],
-    by_switch=False
+    by_switch=False,
 ):
     """Log the information of installing or deleting flows. The logs will
-     show the quantity of flows being modified in each switch or all
-     existent switches.
-     If flows are sent by switch, each switch will log the flows modified."""
+    show the quantity of flows being modified in each switch or all
+    existent switches.
+    If flows are sent by switch, each switch will log the flows modified."""
     log_str = "Batched of flows received: "
     count_flows = 0
     for switch in switches:
         if not by_switch:
-            flows_n = len(flows_dict['flows'])
+            flows_n = len(flows_dict["flows"])
             log_str = log_str + f" switches:{switches}, flows_by_switch:{flows_n}, "
-            count_flows = flows_n*len(switches)
-            _flows_to_log(logger_fun, message, switches, flows_dict['flows'])
+            count_flows = flows_n * len(switches)
+            _flows_to_log(logger_fun, message, switches, flows_dict["flows"])
             break
-        
-        flows_n = len(flows_dict[switch]['flows'])
-        log_str = log_str + f"{{switch: {switch}, flows_lenght: {flows_n}}}, "
+
+        flows_n = len(flows_dict[switch]["flows"])
+        log_str = log_str + f"{{switch: {switch}, flows_lengthq: {flows_n}}}, "
         count_flows += flows_n
-        _flows_to_log(logger_fun, message, [switch], flows_dict[switch]['flows'])
+        _flows_to_log(logger_fun, message, [switch], flows_dict[switch]["flows"])
     logger_fun(f"{log_str} total_flows_length: {count_flows}")
+
 
 def _flows_to_log(
     logger_fun: Callable,
@@ -233,3 +237,12 @@ def _flows_to_log(
             f" {flow_list[i:j]}"
         )
         i, j = j, j + maximun
+
+
+# pylint: disable=simplifiable-if-expression
+def _get_force_from_params(params: QueryParams):
+    force = params.get("force", "false").lower()
+    if force not in {"true", "false"}:
+        msg = "Parameter force does not have a valid value."
+        raise HTTPException(400, detail=msg)
+    return True if force == "true" else False

--- a/utils.py
+++ b/utils.py
@@ -205,7 +205,7 @@ def flows_to_log(
     show the quantity of flows being modified in each switch or all
     existent switches.
     If flows are sent by switch, each switch will log the flows modified."""
-    log_str = "Batched of flows received: "
+    log_str = "Flows received summary: "
     count_flows = 0
     for switch in switches:
         if not by_switch:
@@ -216,7 +216,7 @@ def flows_to_log(
             break
 
         flows_n = len(flows_dict[switch]["flows"])
-        log_str = log_str + f"{{switch: {switch}, flows_lengthq: {flows_n}}}, "
+        log_str = log_str + f"{{switch: {switch}, flows_length: {flows_n}}}, "
         count_flows += flows_n
         _flows_to_log(logger_fun, message, [switch], flows_dict[switch]["flows"])
     logger_fun(f"{log_str} total_flows_length: {count_flows}")
@@ -245,4 +245,4 @@ def _get_force_from_params(params: QueryParams):
     if force not in {"true", "false"}:
         msg = "Parameter force does not have a valid value."
         raise HTTPException(400, detail=msg)
-    return True if force == "true" else False
+    return force == "true"

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,7 @@ from pyof.foundation.base import UBIntBase
 from pyof.v0x04.controller2switch.flow_mod import FlowModCommand
 from typing import Union
 from kytos.core import log
-
+from typing import Union
 from .exceptions import InvalidCommandError
 
 
@@ -188,64 +188,48 @@ def validate_cookies_del(flows: list[dict]) -> None:
                 f"when deleting flows. flow: {flow}"
             )
 
-
-def _flows_to_log(
-    logger_fun: Callable,
-    flows: list,
-    dpid: Union[str, list],
-    counter: int,
-    flows_acc: dict,
-    maximun: int,
-    message: str,
-    total_length: str,
-) -> tuple[int, dict, str]:
-    start, end = 0, counter
-    while flows[start:end]:
-        counter -= len(flows[start:end])
-        flows_acc[str(dpid)] = flows[start: end]
-        dpids = list(flows_acc.keys()) if isinstance(dpid, str) else dpid
-        if counter == 0:
-            counter = maximun
-            logger_fun(f"{message}{dpids}{total_length}, "
-                       f" flows({counter}): {flows_acc}")
-            total_length = ""
-            flows_acc = {}
-        start += len(flows[start:end])
-        end += counter
-    return counter, flows_acc, total_length
-
-
 def flows_to_log(
     logger_fun: Callable,
     message: str,
-    dpid: list,
-    content_dict: dict[str, dict],
-    by_switch=False,
+    switches: list[str],
+    flows_dict: Union[
+        dict[str, dict[str, list]], # by_switch=True
+        dict[str, list]             # by_switch=False
+    ],
+    by_switch=False
 ):
-    """New flog to log"""
+    """Log the information of installing or deleting flows. The logs will
+     show the quantity of flows being modified in each switch or all
+     existent switches.
+     If flows are sent by switch, each switch will log the flows modified."""
+    log_str = "Batched of flows received: "
+    count_flows = 0
+    for switch in switches:
+        if not by_switch:
+            flows_n = len(flows_dict['flows'])
+            log_str = log_str + f" switches:{switches}, flows_by_switch:{flows_n}, "
+            count_flows = flows_n*len(switches)
+            _flows_to_log(logger_fun, message, switches, flows_dict['flows'])
+            break
+        
+        flows_n = len(flows_dict[switch]['flows'])
+        log_str = log_str + f"{{switch: {switch}, flows_lenght: {flows_n}}}, "
+        count_flows += flows_n
+        _flows_to_log(logger_fun, message, [switch], flows_dict[switch]['flows'])
+    logger_fun(f"{log_str} total_flows_length: {count_flows}")
+
+def _flows_to_log(
+    logger_fun: Callable,
+    message: str,
+    switches: list[str],
+    flow_list: list,
+):
+    """Logs the flows within a limit."""
     maximun = 200
-    flows_acc = {}
-    counter = maximun
-
-    if not by_switch:
-        flows = content_dict["flows"]
-        total_length = f", total_length: {len(flows)}"
-        counter, flows_acc, total_length = _flows_to_log(
-            logger_fun, flows, dpid, maximun, flows_acc, maximun, message, total_length
+    i, j = 0, maximun
+    while flow_list[i:j]:
+        logger_fun(
+            f"{message}{switches}, flows[{i}, {(j if j < len(flow_list) else len(flow_list))}]:"
+            f" {flow_list[i:j]}"
         )
-
-    else:
-        total_length = 0
-        for dpid in content_dict:
-            total_length += len(content_dict[dpid]["flows"])
-        total_length = f", total_length: {total_length}"
-        for dpid in content_dict:
-            flows = content_dict[dpid]["flows"]
-            counter, flows_acc, total_length = _flows_to_log(
-                logger_fun, flows, dpid, counter, flows_acc, maximun, message, total_length
-            )
-
-    if flows_acc:
-        dpids = list(flows_acc.keys()) if isinstance(dpid, str) else dpid
-        logger_fun(f"{message}{dpids}{total_length}, "
-                   f"flows({maximun-counter}): {flows_acc}")
+        i, j = j, j + maximun


### PR DESCRIPTION
Closes #202 

### Summary

Added requests for installation and deletion flows and specified switches in the content:
- `POST .../api/kytos/flow_manager/v2/flows/flows_by_switch` with content as:
```
{
    "00:00:00:00:00:00:00:03": {
        "flows": [{"match": {"in_port": 3, "dl_vlan": 1}, "cookie": 12297829382473034410, "actions": [{"action_type": "set_vlan", "vlan_id": 1}, {"action_type": "output", "port": 2}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}, {"match": {"in_port": 2, "dl_vlan": 1}, "cookie": 12297829382473034410, "actions": [{"action_type": "set_vlan", "vlan_id": 1}, {"action_type": "output", "port": 3}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}]
    },
    "00:00:00:00:00:00:00:02": {
        "flows": [{"match": {"in_port": 3, "dl_vlan": 1}, "cookie": 12297829382473034410, "actions": [{"action_type": "set_vlan", "vlan_id": 1}, {"action_type": "output", "port": 2}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}, {"match": {"in_port": 2, "dl_vlan": 1}, "cookie": 12297829382473034410, "actions": [{"action_type": "set_vlan", "vlan_id": 1}, {"action_type": "output", "port": 3}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}]
    },
    "00:00:00:00:00:00:00:04": {
        "flows": [{"match": {"in_port": 1, "dl_vlan": 123}, "cookie": 12297829382473034410, "actions": [{"action_type": "push_vlan", "tag_type": "s"}, {"action_type": "set_vlan", "vlan_id": 1}, {"action_type": "output", "port": 2}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}, {"match": {"in_port": 2, "dl_vlan": 1}, "cookie": 12297829382473034410, "actions": [{"action_type": "pop_vlan"}, {"action_type": "output", "port": 1}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}]
    },
    "00:00:00:00:00:00:00:01": {
        "flows": [{"match": {"in_port": 1, "dl_vlan": 123}, "cookie": 12297829382473034410, "actions": [{"action_type": "push_vlan", "tag_type": "s"}, {"action_type": "set_vlan", "vlan_id": 1}, {"action_type": "output", "port": 3}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}, {"match": {"in_port": 3, "dl_vlan": 1}, "cookie": 12297829382473034410, "actions": [{"action_type": "pop_vlan"}, {"action_type": "output", "port": 1}], "owner": "mef_eline", "table_group": "evpl", "table_id": 0, "priority": 20000}]
    }
}
```
- `DELETE .../api/kytos/flow_manager/v2/flows/flows_by_switch` with content as:
```
{
    "00:00:00:00:00:00:00:03": {
        "flows": [{"cookie": 12297829382473034410, "cookie_mask": 18446744073709551615, "owner": "mef_eline"}]
    },
    "00:00:00:00:00:00:00:02": {
        "flows": [{"cookie": 12297829382473034410, "cookie_mask": 18446744073709551615, "owner": "mef_eline"}]
    },
    "00:00:00:00:00:00:00:04": {
        "flows": [{"cookie": 12297829382473034410, "cookie_mask": 18446744073709551615, "owner": "mef_eline"}]
    }
}
```
Both requests have the possible parameter `force` for all the switches. By default its value is `False`

- Fixed repeated `.messages.out.ofpt_flow_mod` events when creating and deleting flows in all the switches.
- API requests `POST v2/flows` and `DELETE v2/flows` now include a new key `"switches"` to specified which switches will have the same flows being sent in the API content.

### Local Tests
Sent the contents specified previously.

### End-to-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 271 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 44%]
tests/test_e2e_15_mef_eline.py .....                                     [ 46%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ........................R..            [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```

