### PR TITLE
fix: only update flows as `'installed'` if they were `'pending'`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Only update flows as ``'installed'`` if they were ``'pending'``. This fixed processing late barrier replies correctly even if there was a recent related flow deletion.
+
 [2024.1.2] - 2024-09-06
 ***********************
 

--- a/tests/unit/test_flow_controller.py
+++ b/tests/unit/test_flow_controller.py
@@ -79,6 +79,16 @@ class TestFlowController:  # pylint: disable=too-many-public-methods
         assert arg1 == {"flow_id": {"$in": [self.flow_id]}}
         assert arg2["$set"]["state"] == "installed"
 
+    def test_update_flows_state_from_filter(self) -> None:
+        """Test update_flows_state with from filter."""
+        from_state = "pending"
+        assert self.flow_controller.update_flows_state(
+            [self.flow_id], "installed", "pending"
+        )
+        arg1, arg2 = self.flow_controller.db.flows.update_many.call_args[0]
+        assert arg1 == {"flow_id": {"$in": [self.flow_id]}, "state": from_state}
+        assert arg2["$set"]["state"] == "installed"
+
     def test_delete_flow_by_id(self) -> None:
         """Test delete_flow_by_id."""
         assert self.flow_controller.delete_flow_by_id(self.flow_id)


### PR DESCRIPTION
Closes #209 

### Summary

- Only update flows as ``'installed'`` if they were ``'pending'``. This fixed processing late barrier replies correctly even if there was a recent related flow deletion.

### Local Tests

- Ran the same as issue #209, it no longer happens

```
kytos $> 2024-11-01 14:30:09,389 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, tota
l_length: 1,  flows[0, 1]: [{'match': {'in_port': 1, 'dl_vlan': 200}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'output', 'port': 2}]}]}]
2024-11-01 14:30:09,398 - INFO [uvicorn.access] (MainThread) 127.0.0.1:50586 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-01 14:30:09,405 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: False, total_leng
th: 1,  flows[0, 1]: [{'match': {'in_port': 1, 'dl_vlan': 200}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'output', 'port': 2}]}]}]
2024-11-01 14:30:09,412 - INFO [uvicorn.access] (MainThread) 127.0.0.1:50592 - "DELETE /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202

rs0 [direct: primary] napps> db.flows.find({"switch": "00:00:00:00:00:00:00:01", "flow.match.in_port": 1, "flow.match.dl_vlan": 200})
[
  {
    _id: 'f7d62685768a4072275ac13c54f12c14',
    flow: {
      table_id: 0,
      table_group: 'base',
      priority: 32768,
      cookie: Decimal128("0"),
      idle_timeout: 0,
      hard_timeout: 0,
      match: { in_port: 1, dl_vlan: 200 },
      instructions: [
        {
          instruction_type: 'apply_actions',
          actions: [ { action_type: 'output', port: 2 } ]
        }
      ]
    },
    flow_id: '085b6b19a3d68ed4066bb67aef69f0cf',
    id: 'f7d62685768a4072275ac13c54f12c14',
    inserted_at: ISODate("2024-11-01T17:29:44.143Z"),
    state: 'deleted',
    switch: '00:00:00:00:00:00:00:01',
    updated_at: ISODate("2024-11-01T17:30:09.409Z")
  }
]
```

- I also stress tested with 100 requests/sec installing a flow to ensure the extra query during the barrier reply was performing well as expected, and it is, minimal extra threaded delay:

![20241101_142501](https://github.com/user-attachments/assets/0a566981-5359-4746-9900-7117c483c238)

```
    op: 'query',
    ns: 'napps.flows',
    command: {
      find: 'flows',
      filter: { flow_id: { '$in': [ 1, 2, 3 ] }, state: 'pending' },
      readConcern: { level: 'majority' },
      lsid: { id: new UUID("5120e573-a499-4dec-8a98-8b4da722198d") },
      '$clusterTime': {
        clusterTime: Timestamp({ t: 1730481619, i: 1 }),
        signature: {
          hash: Binary(Buffer.from("0000000000000000000000000000000000000000", "hex"), 0),
          keyId: Long("0")
        }
      },
      '$db': 'napps',
      '$readPreference': { mode: 'primaryPreferred' }
    },
    ...
   planSummary: 'IXSCAN { state: 1 }',

```

### End-to-End Tests

With this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 243 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 13456.17s (3:44:16) =
```
