### PR TITLE
[release 2023.2.1]f ix: only update flows as `'installed'` if they were `'pending'`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.1] - 2024-11-01
+***********************
+
+Fixed
+=====
+- Only update flows as ``'installed'`` if they were ``'pending'``. This fixed processing late barrier replies correctly even if there was a recent related flow deletion.
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -114,13 +114,16 @@ class FlowController:
             return_document=ReturnDocument.AFTER,
         )
 
-    def update_flows_state(self, flow_ids: List[str], state: str) -> int:
+    def update_flows_state(
+        self, flow_ids: List[str], state: str, from_state: Optional[str] = None
+    ) -> int:
         """Bulk update flows state."""
         update_expr = {"$set": {"state": state}}
         self._set_updated_at(update_expr)
-        return self.db.flows.update_many(
-            {"flow_id": {"$in": flow_ids}}, update_expr
-        ).modified_count
+        filter_expr = {"flow_id": {"$in": flow_ids}}
+        if from_state:
+            filter_expr["state"] = from_state
+        return self.db.flows.update_many(filter_expr, update_expr).modified_count
 
     def delete_flow_by_id(self, flow_id: str) -> int:
         """Delete flow by id."""
@@ -175,6 +178,17 @@ class FlowController:
     def get_flows_by_state(self, dpid: str, state: str) -> Iterator[dict]:
         """Get flows by state."""
         for flow in self.db.flows.find({"switch": dpid, "state": state}):
+            flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
+            yield flow
+
+    def get_flows_by_flow_id(
+        self, flow_ids: list[str], state: Optional[str] = None
+    ) -> Iterator[dict]:
+        """Get flows by flow_id."""
+        filter_expr = {"flow_id": {"$in": flow_ids}}
+        if state:
+            filter_expr["state"] = state
+        for flow in self.db.flows.find(filter_expr):
             flow["flow"]["cookie"] = int(flow["flow"]["cookie"].to_decimal())
             yield flow
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2023.2.0",
+  "version": "2023.2.1",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/main.py
+++ b/main.py
@@ -223,10 +223,26 @@ class Main(KytosNApp):
 
     def _publish_installed_flow(self, switch, flows):
         """Publish installed flow when it's confirmed."""
+        if not flows:
+            return
+
+        pending_flows = {
+            flow["flow_id"]: flow
+            for flow in self.flow_controller.get_flows_by_flow_id(
+                [flow.id for flow in flows], state=FlowEntryState.PENDING.value
+            )
+        }
+        if not pending_flows:
+            return
+
         for flow in flows:
-            self._send_napp_event(switch, flow, "add")
+            if flow.id in pending_flows:
+                self._send_napp_event(switch, flow, "add")
+
         self.flow_controller.update_flows_state(
-            [flow.id for flow in flows], FlowEntryState.INSTALLED.value
+            list(pending_flows.keys()),
+            FlowEntryState.INSTALLED.value,
+            from_state=FlowEntryState.PENDING.value,
         )
 
     @listen_to("kytos/of_core.flow_stats.received")
@@ -258,7 +274,9 @@ class Main(KytosNApp):
 
         if flow_ids_to_update:
             self.flow_controller.update_flows_state(
-                flow_ids_to_update, FlowEntryState.INSTALLED.value
+                flow_ids_to_update,
+                FlowEntryState.INSTALLED.value,
+                from_state=FlowEntryState.PENDING.value,
             )
 
     def _retry_on_openflow_connection_error(


### PR DESCRIPTION
Closes #209 

### Summary

See https://github.com/kytos-ng/flow_manager/pull/211/files for more information

### Local Tests

I also ran this branch on 2023.2.1, it worked:

```

     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2023.2.0

2024-11-01 14:53:09,216 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51936 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-01 14:53:09,232 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51920 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-01 14:53:10,946 - WARNING [kytos.napps.kytos/of_lldp] (MainThread) LLDP loop detected on switch: 00:00:00:00:00:00:00:01, interfaces: ['s1-eth7', 's1-eth8'], port_numbers: [7, 8]
2024-11-01 14:53:10,946 - WARNING [kytos.napps.kytos/of_lldp] (MainThread) LLDP loop detected on switch: 00:00:00:00:00:00:00:01, interfaces: ['s1-eth5', 's1-eth6'], port_numbers: [5, 6]
2024-11-01 14:53:10,947 - WARNING [kytos.napps.kytos/of_lldp] (MainThread) LLDP loop detected on switch: 00:00:00:00:00:00:00:03, interfaces: ['s3-eth5', 's3-eth6'], port_numbers: [5, 6]
                                                                                                                                                                             

kytos $> 2024-11-01 14:53:18,984 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows
[0, 1]: [{'match': {'in_port': 1, 'dl_vlan': 200}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'output', 'port': 2}]}]}]
2024-11-01 14:53:18,989 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57034 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-01 14:53:18,997 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: False,  flows[0, 1]
: [{'match': {'in_port': 1, 'dl_vlan': 200}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'output', 'port': 2}]}]}]
```

### End-to-End Tests

See https://github.com/kytos-ng/flow_manager/pull/211/files for more information