### PR TITLE
[release 2024.1.3] fix: only update flows as `'installed'` if they were `'pending'`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.3] - 2024-11-04
+***********************
+
+Fixed
+=====
+- Only update flows as ``'installed'`` if they were ``'pending'``. This fixed processing late barrier replies correctly even if there was a recent related flow deletion.
+
 [2024.1.2] - 2024-09-06
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2024.1.2",
+  "version": "2024.1.3",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",


### PR DESCRIPTION
Closes #210 

### Summary

See https://github.com/kytos-ng/flow_manager/pull/211 for more information

### Local Tests


```
WARNING kytos (2024.1.2) and kytos utils (2024.1.0) versions are not equal.

Status |           NApp ID            |                                    Description                                   
=======+==============================+==================================================================================
 [ie]  | amlight/sdntrace_cp:2024.1.0 | Run tracepaths on OpenFlow in the Control Plane                                  
 [ie]  | kytos/flow_manager:2024.1.3  | Manage switches' flows through a REST API.                                       
 [ie]  | kytos/mef_eline:2024.1.5     | NApp to provision circuits from user request                                     
 [ie]  | kytos/of_core:2024.1.0       | OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.     
 [ie]  | kytos/of_lldp:2024.1.0       | Discover network-to-network interfaces (NNIs) using the LLDP protocol.           
 [ie]  | kytos/pathfinder:2024.1.0    | Keeps track of topology changes, and calculates the best path between two points.
 [ie]  | kytos/topology:2024.1.4      | Manage the network topology.                                                     

Status: (i)nstalled, (e)nabled
```

- Installed and deleted a flow:


```

     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2024.1.2

kytos $> 2024-11-04 13:02:12,858 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, total
_length: 1,  flows[0, 1]: [{'match': {'in_port': 1, 'dl_vlan': 200}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'output', 'port': 2}]}]}]
2024-11-04 13:02:12,864 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60216 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-04 13:02:12,871 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: False, total_lengt
h: 1,  flows[0, 1]: [{'match': {'in_port': 1, 'dl_vlan': 200}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'output', 'port': 2}]}]}]
2024-11-04 13:02:12,878 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60228 - "DELETE /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
kytos $> 


rs0 [direct: primary] napps> db.flows.find({"switch": "00:00:00:00:00:00:00:01", "flow.match.in_port": 1, "flow.match.dl_vlan": 200})
[
  {
    _id: 'f7d62685768a4072275ac13c54f12c14',
    flow: {
      table_id: 0,
      table_group: 'base',
      priority: 32768,
      cookie: Decimal128("0"),
      idle_timeout: 0,
      hard_timeout: 0,
      match: { in_port: 1, dl_vlan: 200 },
      instructions: [
        {
          instruction_type: 'apply_actions',
          actions: [ { action_type: 'output', port: 2 } ]
        }
      ]
    },
    flow_id: '085b6b19a3d68ed4066bb67aef69f0cf',
    id: 'f7d62685768a4072275ac13c54f12c14',
    inserted_at: ISODate("2024-11-04T16:02:12.860Z"),
    state: 'deleted',
    switch: '00:00:00:00:00:00:00:01',
    updated_at: ISODate("2024-11-04T16:02:12.875Z")
  }
]
rs0 [direct: primary] napps> 
```


### End-to-End Tests

https://github.com/kytos-ng/flow_manager/pull/211
