### PR TITLE
Issue 207 - Append unmentioned events to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,38 @@ Subscribed
 Generated
 ---------
 
+kytos/flow_manager.messages.out.ofpt_barrier_request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*buffer*: ``app``
+
+Event reporting that a Barrier Request was sent to a switch.
+
+Content:
+
+.. code-block:: python3
+
+   {
+     'datapath': <Switch object>
+     'flow': <Object representing the barrier request>
+   }
+
+kytos/flow_manager.messages.out.ofpt_flow_mod
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*buffer*: ``app``
+
+Event reporting that a FlowMod was sent to a switch.
+
+Content:
+
+.. code-block:: python3
+
+   {
+     'datapath': <Switch object>
+     'flow': <Object representing the flow>
+   }
+
 kytos/flow_manager.flow.pending
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Description:

## Changes:
---
- Added kytos/flow_manager.messages.out.ofpt_barrier_request to README
- Added kytos/flow_manager.messages.out.ofpt_flow_mod to README

Closes #207 

## Summary

Two events were not mentioned in the README, as mentioned in issue 207. This MR seeks to update the README with the new events appended to the "Generated" section.
