### PR TITLE
Changed flows matches with empty "match"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
 - Changed alien flows to have ``alien`` as owner. Alien flow deletion is now paced by ``send_flow_mod.alien``.
 - Increased ``telemetry_int`` pacing rate to 300/second
 - Added ``switches`` proterty to requests ``POST v2/flows`` and ``DELETE v2/flows`` to add flows to all switches in the list from ``switches``
+- When a deletion flow is sent, it does not longer deletes flows without the ``"match"`` field. A deletion flow without match will still be match with all other flows whether they have the ``"match"`` field or not.
 
 [2024.1.1] - 2024-08-30
 ***********************

--- a/tests/unit/test_match_13.py
+++ b/tests/unit/test_match_13.py
@@ -99,7 +99,6 @@ def test_match_cookie(to_install, stored, should_match):
             {"match": {}},
             True,
         ),
-
     ],
 )
 def test_empty_match(to_install, stored, should_match) -> None:

--- a/tests/unit/test_match_13.py
+++ b/tests/unit/test_match_13.py
@@ -89,6 +89,17 @@ def test_match_cookie(to_install, stored, should_match):
             {"match": {"in_port": 1}},
             False,
         ),
+        (
+            {"match": {"in_port": 1}},
+            {"match": {}},
+            False,
+        ),
+        (
+            {"match": {}},
+            {"match": {}},
+            True,
+        ),
+
     ],
 )
 def test_empty_match(to_install, stored, should_match) -> None:

--- a/tests/unit/test_match_13.py
+++ b/tests/unit/test_match_13.py
@@ -99,6 +99,11 @@ def test_match_cookie(to_install, stored, should_match):
             {"match": {}},
             True,
         ),
+        (
+            {"match": {"in_port": 1}},
+            {"table_id": 1},
+            False,
+        ),
     ],
 )
 def test_empty_match(to_install, stored, should_match) -> None:

--- a/v0x04/match.py
+++ b/v0x04/match.py
@@ -43,11 +43,11 @@ def match13_no_strict(flow_to_install, stored_flow_dict):
         return False
     if not _match_table_id(flow_to_install, stored_flow_dict):
         return False
-    if "match" not in flow_to_install or "match" not in stored_flow_dict:
+    if "match" not in flow_to_install:
         return stored_flow_dict
     if not flow_to_install["match"]:
         return stored_flow_dict
-    if len(flow_to_install["match"]) > len(stored_flow_dict["match"]):
+    if "match" not in stored_flow_dict or (len(flow_to_install["match"]) > len(stored_flow_dict["match"])):
         return False
 
     if not _match_keys(

--- a/v0x04/match.py
+++ b/v0x04/match.py
@@ -47,7 +47,7 @@ def match13_no_strict(flow_to_install, stored_flow_dict):
         return stored_flow_dict
     if not flow_to_install["match"]:
         return stored_flow_dict
-    if "match" not in stored_flow_dict or (len(flow_to_install["match"]) > len(stored_flow_dict["match"])):
+    if (len(flow_to_install["match"]) > len(stored_flow_dict.get("match", []))):
         return False
 
     if not _match_keys(


### PR DESCRIPTION
Closes #196

### Summary

Stored flows with empty `"match"` will not longer match every flows deletion with the same table ID.

### Local Tests
Repeated the issue case
Updated unit tests

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 277 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 48%]
tests/test_e2e_20_flow_manager.py ..........................             [ 57%]
tests/test_e2e_21_flow_manager.py ...                                    [ 58%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```