### PR TITLE
fix: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ file.
 Fixed
 =====
 - Only update flows as ``'installed'`` if they were ``'pending'``. This fixed processing late barrier replies correctly even if there was a recent related flow deletion.
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
 
 [2024.1.2] - 2024-09-06
 ***********************

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -10,7 +10,7 @@ from typing import Iterator, List, Optional, Union
 import pymongo
 from bson.decimal128 import Decimal128
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -31,7 +31,7 @@ from ..db.models import FlowCheckDoc, FlowDoc
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class FlowController:
     """FlowController."""


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/535

### Summary

- See updated changelog file 
- Index creation timeout didn't get ajusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/539 

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/539 