### PR TITLE
release 2024.1.5: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.5] - 2025-03-03
+***********************
+
+Fixed
+=====
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
+
 [2024.1.4] - 2025-02-19
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -10,7 +10,7 @@ from typing import Iterator, List, Optional, Union
 import pymongo
 from bson.decimal128 import Decimal128
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -31,7 +31,7 @@ from ..db.models import FlowCheckDoc, FlowDoc
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class FlowController:
     """FlowController."""

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2024.1.4",
+  "version": "2024.1.5",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1240,12 +1240,17 @@ class TestMain:
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
         switch.id = dpid
-        flows = [MagicMock(id="1")]
+        flows = [MagicMock(id="1"), MagicMock(id="2")]
+        self.napp.flow_controller.get_flows_by_flow_id.return_value = [
+            {"flow_id": flow.id} for flow in flows
+        ]
         self.napp._publish_installed_flow(switch, flows)
-        mock_send_napp_event.assert_called()
-        self.napp.flow_controller.update_flows_state.assert_called_with(
-            [flow.id for flow in flows], "installed"
-        )
+        assert mock_send_napp_event.call_count == len(flows)
+        args = self.napp.flow_controller.update_flows_state.call_args
+        assert args[0][0] == [flow.id for flow in flows]
+        assert args[0][1] == "installed"
+        assert "from_state" in args[1]
+        assert args[1]["from_state"] == "pending"
 
     @patch("napps.kytos.flow_manager.main.Main._send_barrier_request")
     def test_retry_on_openflow_connection_error(self, mock_barrier):


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/538

- See updated changelog file 
- Index creation timeout didn't get adjusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/541

### Unit tests

```
coverage: OK ✔ in 45.99 seconds
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /home/viniarck/repos/ky20241/flow_manager/.tox/py311
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished black
INFO: Finished pylint
:) No issues found.
[isort] Skipped 5 files
No linter error found.
  coverage: OK (45.99=setup[32.27]+cmd[13.72] seconds)
  lint: OK (43.11=setup[33.33]+cmd[9.78] seconds)
  congratulations :) (89.14 seconds)
```

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/541 