### PR TITLE
Added missing `by_switch` parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ file.
 
 Fixed
 =====
+- Bulk deletion ``by_switch`` would use not ``by_switch`` method to parametrize cookies causing mismatched cookies with multiple switches from the same request.
+
+[2025.1.0] - 2025-04-14
+***********************
+
+Fixed
+=====
 - Only update flows as ``'installed'`` if they were ``'pending'``. This fixed processing late barrier replies correctly even if there was a recent related flow deletion.
 - DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
 

--- a/main.py
+++ b/main.py
@@ -517,14 +517,14 @@ class Main(KytosNApp):
                 # no more looping necessary
                 cookie_ranges = merge_cookie_ranges(cookie_ranges_dict[dpid])
                 flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(
-                    switches_list, cookie_ranges
+                    switches_list, cookie_ranges, by_switch=by_switch
                 )
                 break
         if by_switch:
             for dpid, cookie_ranges in cookie_ranges_dict.items():
                 cookie_ranges_dict[dpid] = merge_cookie_ranges(cookie_ranges)
             flows_from_db = self.flow_controller.get_flows_by_cookie_ranges(
-                switches_list, cookie_ranges_dict, by_switch=True
+                switches_list, cookie_ranges_dict, by_switch=by_switch
             )
         for dpid, stored_flows in flows_from_db.items():
             for flow_dict in flow_dicts[dpid]:
@@ -833,12 +833,19 @@ class Main(KytosNApp):
                     flows_dict,
                     switches,
                     reraise_conn=not force,
+                    by_switch=by_switch,
                 )
                 return JSONResponse(
                     {"response": "FlowMod Messages Sent"}, status_code=202
                 )
 
-            self._install_flows(command, flows_dict, switches, reraise_conn=not force)
+            self._install_flows(
+                command,
+                flows_dict,
+                switches,
+                reraise_conn=not force,
+                by_switch=by_switch,
+            )
             return JSONResponse({"response": "FlowMod Messages Sent"}, status_code=202)
 
         except SwitchNotConnectedError as error:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -429,6 +429,19 @@ class TestMain:
         assert args[1] == flows
         assert args[2] == [self.switch_01]
 
+        flows_by_switch = {
+            "00:00:00:00:00:00:00:01": {"flows": [{"match": {"in_port": 1}}]}
+        }
+        response = await self.api_client.post(
+            f"{self.base_endpoint}/flows_by_switch", json=flows_by_switch
+        )
+        assert response.status_code == 202
+        args1, args2 = mock_install_flows.call_args
+        assert args1[0] == "add"
+        assert args1[1] == flows_by_switch
+        assert args1[2] == [self.switch_01]
+        assert args2["by_switch"] is True
+
         # Error, switch not found
         flows["switches"].append("non_switch")
         response = await self.api_client.post(f"{self.base_endpoint}/flows", json=flows)


### PR DESCRIPTION
Closes #234

### Summary

Added missing `by_switch` parameters

### Local Tests
Unit test results.
```
tests/integration/test_main.py ..                                                                                                                                                                                                      [  1%]
tests/unit/test_barrier_request.py .                                                                                                                                                                                                   [  2%]
tests/unit/test_db_models.py ...                                                                                                                                                                                                       [  4%]
tests/unit/test_flow_controller.py ..............                                                                                                                                                                                      [ 13%]
tests/unit/test_main.py .................................................................                                                                                                                                              [ 57%]
tests/unit/test_match_13.py ...................                                                                                                                                                                                        [ 70%]
tests/unit/test_utils.py ............................................                                                                                                                                                                  [100%]
```
Also performed related e2e [test](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/373/files)

### End-to-End Tests
N/A