### PR TITLE
fix: update kytos.json that was missing

### DIFF
--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "flow_manager",
   "description": "Manage switches' flows through a REST API.",
-  "version": "2025.1.0",
+  "version": "2025.1.1",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "url": "https://github.com/kytos/flow_manager.git",


### PR DESCRIPTION
### Summary

This PR fixes the `kytos.json` file that was missing from PR #235 and #236

### Local Tests

N/A

### End-to-End Tests

Not needed.