### PR TITLE
fix: purged xids from flow mods error dict to avoid unbounded growth (mem leak related)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Purged xids from flow mods error dict to avoid unbounded growth
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ class Main(KytosNApp):
         self._pending_barrier_lock = Lock()
         self._pending_barrier_max_size = FLOWS_DICT_MAX_SIZE
 
-        self._flow_mods_sent_error = {}
+        self._flow_mods_sent_error = OrderedDict()
         self._flow_mods_retry_count = {}
         self._flow_mods_retry_count_lock = Lock()
         self.resent_flows = set()
@@ -225,6 +225,9 @@ class Main(KytosNApp):
                 ):
                     continue
                 flows.append(flow)
+        for flow_xid in flow_xids:
+            self._flow_mods_sent_error.pop(flow_xid, None)
+            self._flow_mods_retry_count.pop(flow_xid, None)
         """
         It should only publish installed flow if it the original FlowMod xid hasn't
         errored out. OFPT_ERROR messages could be received first if the barrier request
@@ -336,6 +339,7 @@ class Main(KytosNApp):
                     f"switch {switch.id}, command: {command}, flow: {flow.as_dict()}"
                 )
                 self._send_openflow_connection_error(event)
+                self._flow_mods_retry_count.pop(xid, None)
                 return False
 
             datetime_t2 = now()
@@ -990,7 +994,9 @@ class Main(KytosNApp):
     def _add_flow_mod_sent(self, xid, flow, command, owner):
         """Add the flow mod to the list of flow mods sent."""
         if len(self._flow_mods_sent) >= self._flow_mods_sent_max_size:
-            self._flow_mods_sent.popitem(last=False)
+            evicted_xid, _ = self._flow_mods_sent.popitem(last=False)
+            self._flow_mods_sent_error.pop(evicted_xid, None)
+            self._flow_mods_retry_count.pop(evicted_xid, None)
         self._flow_mods_sent[xid] = (flow, command, owner)
 
     def _add_barrier_request(self, dpid, barrier_xid, flow_mods):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -774,9 +774,7 @@ class TestMain:
         flow_xid = 123
         flow_mods = [MagicMock(header=MagicMock(xid=flow_xid))]
         self.napp._send_barrier_request(switch, flow_mods)
-        barrier_xid = list(
-            self.napp._pending_barrier_reply[switch.id].keys()
-        )[-1]
+        barrier_xid = list(self.napp._pending_barrier_reply[switch.id].keys())[-1]
         self.napp._add_flow_mod_sent(flow_xid, flow_mods[0], "add", "no_owner")
         self.napp._flow_mods_sent_error[flow_xid] = {"error": 1}
         self.napp._flow_mods_retry_count[flow_xid] = (1, MagicMock(), 0.2)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -744,6 +744,67 @@ class TestMain:
 
         assert self.napp._flow_mods_sent[xid] == (flow, "add", "no_owner")
 
+    def test_add_flow_mod_sent_evicts(self):
+        """When _flow_mods_sent evicts its oldest xid, the matching
+        _flow_mods_sent_error  _flow_mods_retry_count entries are evicted too,
+        so they cannot outlive their twin memory leak."""
+        self.napp._flow_mods_sent_max_size = 2
+        self.napp._flow_mods_sent.clear()
+        self.napp._flow_mods_sent_error.clear()
+        self.napp._flow_mods_retry_count.clear()
+
+        self.napp._add_flow_mod_sent(1, MagicMock(), "add", "owner")
+        self.napp._flow_mods_sent_error[1] = {"error": 1}
+        self.napp._flow_mods_retry_count[1] = (1, MagicMock(), 0.2)
+
+        self.napp._add_flow_mod_sent(2, MagicMock(), "add", "owner")
+        self.napp._add_flow_mod_sent(3, MagicMock(), "add", "owner")
+
+        assert 1 not in self.napp._flow_mods_sent
+        assert 1 not in self.napp._flow_mods_sent_error
+        assert 1 not in self.napp._flow_mods_retry_count
+
+    @patch("napps.kytos.flow_manager.main.Main._publish_installed_flow")
+    def test_on_ofpt_barrier_reply_pops_error_and_retry(self, _mock_publish):
+        """Barrier reply drops error retry bookkeeping for the
+        reconciled xids so both dicts stay bounded."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        switch.id = dpid
+        flow_xid = 123
+        flow_mods = [MagicMock(header=MagicMock(xid=flow_xid))]
+        self.napp._send_barrier_request(switch, flow_mods)
+        barrier_xid = list(
+            self.napp._pending_barrier_reply[switch.id].keys()
+        )[-1]
+        self.napp._add_flow_mod_sent(flow_xid, flow_mods[0], "add", "no_owner")
+        self.napp._flow_mods_sent_error[flow_xid] = {"error": 1}
+        self.napp._flow_mods_retry_count[flow_xid] = (1, MagicMock(), 0.2)
+
+        event = MagicMock()
+        event.message.header.xid = barrier_xid
+        event.source.switch = switch
+        self.napp._on_ofpt_barrier_reply(event)
+
+        assert flow_xid not in self.napp._flow_mods_sent_error
+        assert flow_xid not in self.napp._flow_mods_retry_count
+
+    @patch("napps.kytos.flow_manager.main.Main._send_openflow_connection_error")
+    def test_retry_pops_retry_count_on_max_retries(self, _mock_send):
+        """When retries are exhausted the retry counter entry is removed so
+        _flow_mods_retry_count does not grow one entry per errored xid."""
+        xid = 42
+        self.napp._flow_mods_sent = {xid: (MagicMock(), "add", "owner")}
+        event = MagicMock()
+        event.message.header.message_type = Type.OFPT_FLOW_MOD
+        event.message.header.xid = xid
+        self.napp._flow_mods_retry_count[xid] = (5, MagicMock(), 0.2)
+        result = self.napp._retry_on_openflow_connection_error(
+            event, max_retries=5, min_wait=0.2, multiplier=2
+        )
+        assert result is False
+        assert xid not in self.napp._flow_mods_retry_count
+
     def test_send_flow_mod(self):
         """Test _send_flow_mod method."""
         mock_buffers_put = MagicMock()


### PR DESCRIPTION
Closes #243 

### Summary

See updated changelog file

### Local Tests

Verified locally with an ofpt error it popped it

### End-to-End Tests

With this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 309 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx..                                 [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .......                                   [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ......                                      [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
=============================== warnings summary ===============================
tests/test_e2e_01_kytos_startup.py: 17 warnings
------------------------------- start/stop times -------------------------------
= 297 passed, 9 skipped, 2 xfailed, 1 xpassed, 1394 warnings in 15914.09s (4:25:14) =
```