### PR TITLE
fix: prune `_flow_mods_sent` dict after using the xid to cut memory usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ file.
 Fixed
 =====
 - Purged xids from flow mods error dict to avoid unbounded growth
+- Prune _flow_mods_sent dict after using the xid to cut memory usage
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/main.py
+++ b/main.py
@@ -218,10 +218,7 @@ class Main(KytosNApp):
                         f"Failled to pop flow_xid {flow_xid}, dict length: {length}"
                     )
                     continue
-                if (
-                    cmd != "add"
-                    or flow_xid in self._flow_mods_sent_error
-                ):
+                if cmd != "add" or flow_xid in self._flow_mods_sent_error:
                     continue
                 flows.append(flow)
         for flow_xid in flow_xids:

--- a/main.py
+++ b/main.py
@@ -211,7 +211,7 @@ class Main(KytosNApp):
         with self._flow_mods_sent_lock:
             for flow_xid in flow_xids:
                 try:
-                    flow, cmd, _ = self._flow_mods_sent[flow_xid]
+                    flow, cmd, _ = self._flow_mods_sent.pop(flow_xid)
                 except KeyError:
                     length = len(self._flow_mods_sent)
                     log.error(
@@ -220,7 +220,6 @@ class Main(KytosNApp):
                     continue
                 if (
                     cmd != "add"
-                    or flow_xid not in self._flow_mods_sent
                     or flow_xid in self._flow_mods_sent_error
                 ):
                     continue

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -787,6 +787,29 @@ class TestMain:
         assert flow_xid not in self.napp._flow_mods_sent_error
         assert flow_xid not in self.napp._flow_mods_retry_count
 
+    @patch("napps.kytos.flow_manager.main.Main._publish_installed_flow")
+    def test_on_ofpt_barrier_reply_pops_flow_mods_sent(self, mock_publish):
+        """Barrier reply pops the reconciled xid from _flow_mods_sent so the
+        dict stays bounded, while still publishing the installed flow."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        switch.id = dpid
+        flow_xid = 123
+        flow = MagicMock()
+        flow_mods = [MagicMock(header=MagicMock(xid=flow_xid))]
+        self.napp._send_barrier_request(switch, flow_mods)
+        barrier_xid = list(self.napp._pending_barrier_reply[switch.id].keys())[-1]
+        self.napp._add_flow_mod_sent(flow_xid, flow, "add", "no_owner")
+        assert flow_xid in self.napp._flow_mods_sent
+
+        event = MagicMock()
+        event.message.header.xid = barrier_xid
+        event.source.switch = switch
+        self.napp._on_ofpt_barrier_reply(event)
+
+        assert flow_xid not in self.napp._flow_mods_sent
+        mock_publish.assert_called_once_with(switch, [flow])
+
     @patch("napps.kytos.flow_manager.main.Main._send_openflow_connection_error")
     def test_retry_pops_retry_count_on_max_retries(self, _mock_send):
         """When retries are exhausted the retry counter entry is removed so


### PR DESCRIPTION
Closes #247 

### Summary

See updated changelog file 

The mem optimization (300 MB ish cut) can be seen in the right most chart:

<img width="1907" height="468" alt="mem_ss3" src="https://github.com/user-attachments/assets/707455e1-533e-49f0-b0f7-95bb1f56d6da" />


### Local Tests

Confirmed locally by installing flows and forcing ofpt errors too and confirming all related events were sent 

### End-to-End Tests

```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 309 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx..                                 [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .......                                   [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ......                                      [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 297 passed, 9 skipped, 2 xfailed, 1 xpassed, 1394 warnings in 16088.25s (4:28:08) =
```